### PR TITLE
token: Add header file for tokens

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -6,7 +6,8 @@
 public_sources = \
 	main.c
 
-public_headers =
+public_headers = \
+	token.h
 
 private_sources =
 

--- a/src/token.h
+++ b/src/token.h
@@ -1,0 +1,59 @@
+/* token.h
+ * Ondřej Míchal <xmicha80>
+ * FIT BUT
+ * 03/10/2020
+ */
+
+#ifndef __TOKEN_H__
+#define __TOKEN_H__
+
+typedef enum token_type {
+  INVALID,
+
+  // Types
+  INT, // 42
+  FLOAT64, // 42.42
+  STRING, // "fourtytwo"
+
+  // Control
+  IF, // if
+  ELSE, // else
+  FOR, // for
+
+  // Functions
+  FUNC, // func
+  RETURN, // return
+
+  // Package declaration
+  PACKAGE, // package
+
+  // Assignment
+  DEFINE, // :=
+  ASSIGN, // =
+
+  // Operators
+  ADD, // +
+  SUB, // -
+  MUL, // *
+  DIV, // /
+
+  // Comparators
+  AND, // &&
+  OR, // ||
+  EQL, // ==
+  LSS, // <
+  LEQ, // <=
+  GTR, // >
+  GEQ, // >=
+} token_type;
+
+// FIXME: attribute is quite questionable member of the token struct.
+/**
+ * Token holds information about a scanned lexem
+ */
+typedef struct token {
+  token_type type; /**< Type of the token */
+  void *attribute; /**< Token's attribute (e.g., name of variable, value of int,..). Needs to be casted based on token type */
+} token_t;
+
+#endif // __TOKEN_H__


### PR DESCRIPTION
This is very basic. There's an enumerator with all the different types
of values the token can hold info about and the token struct itself. It
holds info about the token type and an arbitrary "attribute" that could
hold anything (e.g., value of int, nothing for operators, info about a
variable -> in this case it could be a struct with the name, if it is a
pointer, address where the pointer points).

For the more advanced attributes (as in the case of a string) there has
to be done some additional work (definition of the said struct,
functions for working with it,..). But this is still a subject for
future discussion.