### PR TITLE
Update makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,14 +8,16 @@ export CC = /usr/bin/env gcc
 export CFLAGS = -std=c99 -g -pedantic -Wall -Wextra
 export NAME = ifj20compiler
 
-export SOURCE_DIR := $(shell pwd)/src
-export BUILD_DIR := $(shell pwd)/build
+export PROJECT_DIR := $(shell pwd)
+export BUILD_DIR := $(PROJECT_DIR)/build
 
-.PHONY: all install run zip clean help
+export BIN_DIR := $(BUILD_DIR)/bin
+
+.PHONY: all run zip clean help
 
 all:
-	@mkdir -p $(BUILD_DIR)
-	$(MAKE) -C $(SOURCE_DIR)
+	@mkdir -p $(BUILD_DIR) $(BIN_DIR)
+	$(MAKE) -C src
 
 run:
 	src/$(NAME)
@@ -26,6 +28,7 @@ zip:
 clean:
 	@rm -f *.zip
 	@rm -f -r $(BUILD_DIR)
+	@$(MAKE) -s -C src clean
 
 help:
 	@echo "make"

--- a/src/Makefile
+++ b/src/Makefile
@@ -7,6 +7,8 @@ ifeq (0, ${MAKELEVEL})
 $(error invoke "make" from the root build directory)
 endif
 
+target := $(BIN_DIR)/$(NAME)
+
 public_sources = \
 	main.c
 
@@ -25,12 +27,17 @@ compiler_headers = \
 	$(public_headers) \
 	$(private_headers)
 
-compiler_objects = $(BUILD_DIR)/$(compiler_sources:.c=.o)
+compiler_objects = $(compiler_sources:%.c=objects/%.o)
 
-.PHONY: all clean
+.PHONY: all dirs clean
 
-all: $(compiler_objects)
-	$(CC) $(LDFLAGS) $(compiler_objects) -o $(BUILD_DIR)/$(NAME)
-$(BUILD_DIR)/%.o: $(compiler_sources)
-	$(CC) -c $(CFLAGS) -o $@ $<
-$(compiler_objects): $(compiler_headers)
+all: dirs $(target)
+$(target): $(compiler_objects)
+	$(CC) -o $(target) $^ $(LDFLAGS)
+$(compiler_objects): objects/%.o: $(compiler_sources)
+	$(CC) $(CFLAGS) -c $< -o $@
+dirs:
+	@mkdir -p ./objects
+
+clean:
+	@rm -f -r ./objects


### PR DESCRIPTION
List of changes:
- Add execution guard for non-root Makefile
- objects are now put into an objects subdirectory that resides in the
  directory where the source files are
- building objects to a specific directory should now work for all
  source files
- the final binary is put in build/bin instead of just build
- invoking "make" should not cause any more unnecessary recompiles
- removed a fallout "install" in .PHONY in main Makefile

Fixes https://github.com/Coders-of-Gondor/ifj20compiler/issues/5