### PR TITLE
src/Makefile: Fix a fallout from Makefile update

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -38,7 +38,7 @@ compiler_objects = $(compiler_sources:%.c=objects/%.o)
 all: dirs $(target)
 $(target): $(compiler_objects)
 	$(CC) -o $(target) $^ $(LDFLAGS)
-$(compiler_objects): objects/%.o: $(compiler_sources)
+$(compiler_objects): objects/%.o: %.c
 	$(CC) $(CFLAGS) -c $< -o $@
 dirs:
 	@mkdir -p ./objects


### PR DESCRIPTION
I made a mistake when defining a static pattern rule[0].

[0] https://www.gnu.org/software/make/manual/html_node/Static-Usage.html#Static-Usage