### PR TITLE
src/symtable: Add symtable manager

### DIFF
--- a/src/symtable-private.h
+++ b/src/symtable-private.h
@@ -34,3 +34,14 @@ struct symtable {
   struct symtable_body *stb;
 };
 
+struct symtable_manager_body {
+  size_t stack_count;
+  size_t max_stack_count;
+
+  symtable_t *symtables[];
+};
+
+struct symtable_manager {
+  struct symtable_manager_body *stmb;
+};
+

--- a/src/symtable.h
+++ b/src/symtable.h
@@ -66,4 +66,26 @@ static inline int symtable_iterator_equal(symtable_iterator_t it1, symtable_iter
   return it1.ptr == it2.ptr && it1.st == it2.st;
 }
 
+struct symtable_manager;
+typedef struct symtable_manager symtable_manager_t;
+
+symtable_manager_t *symtable_manager_new();
+void symtable_manager_free(symtable_manager_t *stm);
+
+size_t symtable_manager_stack_size(const symtable_manager_t *stm);
+size_t symtable_manager_max_stack_size(const symtable_manager_t *stm);
+
+void symtable_manager_push(symtable_manager_t *stm);
+void symtable_manager_pop(symtable_manager_t *stm);
+
+symtable_t *symtable_manager_get_top(symtable_manager_t *stm);
+
+symtable_iterator_t symtable_manager_find(symtable_manager_t *stm, symtable_key_t key);
+symtable_iterator_t symtable_manager_lookup_add(symtable_manager_t *stm, symtable_key_t key);
+symtable_iterator_t symtable_manager_add(symtable_manager_t *stm, symtable_key_t key);
+
+int symtable_manager_has(symtable_manager_t *stm, symtable_key_t key);
+
+void symtable_manager_remove(symtable_manager_t *stm, symtable_key_t key);
+
 #endif // __SYMTABLE_H__


### PR DESCRIPTION
Symtable manager takes care of maintaining an array of symtables on
which it operates. It implements a set of functions that are similar to
the ones in symtable but with the difference that they work across all
the symtables in the "stack".

The set of functions for symtable manager is quite basic and I wouldn't
call them very efficient. My goal was to provide a basic set of
functions that can "get the job done" and when the needs of the compiler
gain a more solid form the symtable can be altered.

I tried to hunt down as many leaks and segfaults as possible but I'm not
100% that there are none left.

Depends on #14 