### PR TITLE
Drop -pedantic flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 
 export SHELL := /usr/bin/env sh
 export CC = /usr/bin/env gcc
-export CFLAGS = -std=c99 -g -pedantic -Wall -Wextra
+export CFLAGS = -std=c99 -g -Wall -Wextra
 export NAME = ifj20compiler
 
 export PROJECT_DIR := $(shell pwd)


### PR DESCRIPTION
In several places of the project we're already using extensions of GCC
(e.g., 'a' ... 'z' in switch or special case of variadic parameters in
macros). And what's the best way to solve warnings? To hide them :).