### PR TITLE
test: Automatize handling of tested objects

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -19,12 +19,10 @@ tests_sources = \
 	symtable_tests.cpp \
 	token_tests.cpp
 
-tested_sources = \
-	scanner.c \
-	scanner-private.c
-
 tests_objects = $(tests_sources:%.cpp=$(OBJECTS_DIR)/%.o)
-tested_objects = $(tested_sources:%.c=$(OBJECTS_DIR)/%.o)
+
+all_objects = $(wildcard $(OBJECTS_DIR)/*.o)
+tested_objects = $(filter-out $(tests_objects) $(OBJECTS_DIR)/main.o,$(all_objects))
 
 .PHONY: all
 


### PR DESCRIPTION
With this we no longer have to manually add a source file that needs to
be included in the final binary. Now, all the sources in build/objects,
apart from the objects of the test suite and main.o, are included
automatically.