### PR TITLE
Upgrade e2e tests using error codes constants

### DIFF
--- a/tests/e2e/001-basic.bats
+++ b/tests/e2e/001-basic.bats
@@ -3,14 +3,14 @@
 load helpers
 
 @test "Show usage screen when no command is given" {
-  run_compiler 1
+  run_compiler $ERROR_INTERNAL
 }
 
 @test "Run compiler with a valid ifj20 source file" {
-  run_compiler $samples/example1.go 
+  run_compiler $SUCCESS $samples/example1.go 
   [ "$output" = "" ]
 }
 
 @test "Run compiler with a non-existent file" {
-  run_compiler 99 $samples/invalidfile.go
+  run_compiler $ERROR_INTERNAL $samples/invalidfile.go
 }

--- a/tests/e2e/helpers.bash
+++ b/tests/e2e/helpers.bash
@@ -1,7 +1,21 @@
 #!/usr/bin/env bash
 
-IFJ20COMPILER=${IFJ20COMPILER:-./build/bin/ifj20compiler}
-samples="./samples"
+# --- CONSTANTS ---
+readonly IFJ20COMPILER=${IFJ20COMPILER:-./build/bin/ifj20compiler}
+readonly samples="./samples"
+
+# error codes constants
+readonly SUCCESS=0                   # No errors
+readonly ERROR_LEXICAL=1             # Lexeme error
+readonly ERROR_SYNTAX=2              # Error in syntax
+readonly ERROR_SEM_VAR=3             # Semantic error - undefined variable, attempt to redefine variable...
+readonly ERROR_SEM_VAR_TYPE=4        # Semantic error - invalid data type of newly defined variable
+readonly ERROR_SEM_COMPATIBILITY=5   # Semantic error - incompatible data types in arithmetic or string operations, or relational expression
+readonly ERROR_SEM_PROGRAM=6         # Semantic error - invalid number/types of parameters and/or return values
+readonly ERROR_SEM=7                 # Other semantic errors
+readonly ERROR_ZERO=9                # Semantic error - dividing by zero
+readonly ERROR_INTERNAL=99           # Internal error - memory errors...
+# --- CONSTANTS END ---
 
 function run_compiler() {
   expected_rc=0


### PR DESCRIPTION
Change every constant in helper.bash to 'readonly'.

Fix one basic test that had a wrong expected return code.