### PR TITLE
added integer for tracking number of lines in compiled file

### DIFF
--- a/src/scanner-private.c
+++ b/src/scanner-private.c
@@ -24,7 +24,7 @@
  *
  * @param s an instance of scanner
  */
-void scanner_skip_whitespace_comments(scanner_t *s, bool *eol_encountered, int line) {
+void scanner_skip_whitespace_comments(scanner_t *s, bool *eol_encountered, int *line) {
   // debug_entry();
   comment_state state = CLEAN;
 
@@ -34,7 +34,7 @@ void scanner_skip_whitespace_comments(scanner_t *s, bool *eol_encountered, int l
     switch (s->character) {
       case '\n':
         *eol_encountered = true;
-        line++;
+        (*line)++;
 
         if (state & INLINE_COMMENT)
           state = CLEAN;

--- a/src/scanner-private.h
+++ b/src/scanner-private.h
@@ -61,7 +61,7 @@ typedef enum comment_state
   BLOCK_COMMENT = 0x8, /**< the next character is a part of a block comment */
 } comment_state;
 
-void scanner_skip_whitespace_comments(scanner_t *s, bool *eol_encountered, int line);
+void scanner_skip_whitespace_comments(scanner_t *s, bool *eol_encountered, int *line);
 
 int innit_scan(scanner_t *s, token_t *t);
 int scan_num_lit(scanner_t *s, token_t *t);

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -67,7 +67,7 @@ void scanner_free(scanner_t *s) {
  * @retval 99 internal error, failed to allocate memory
  * @retval EOF end of file
  */
-int scanner_scan(scanner_t *s, token_t *t, bool *eol_encountered, int line) {
+int scanner_scan(scanner_t *s, token_t *t, bool *eol_encountered, int *line) {
   debug_entry();
   int return_val;
   string str;

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -18,6 +18,6 @@ typedef struct scanner scanner_t;
 scanner_t *scanner_new(FILE *f);
 void scanner_free(scanner_t *s);
 
-int scanner_scan(scanner_t *s, token_t *t, bool *eol_encountered, int line);
+int scanner_scan(scanner_t *s, token_t *t, bool *eol_encountered, int *line);
 
 #endif // __SCANNER_H__

--- a/tests/unit/scanner_tests.cpp
+++ b/tests/unit/scanner_tests.cpp
@@ -29,7 +29,9 @@ TEST_F(scanner_basic_tests, initialize) {
 }
 
 TEST_F(scanner_basic_tests, call_scan_with_no_file_set) {
-    int ret = scanner_scan(s, &t, 0);
+    bool eol_encountered = false;
+    int line = 0;
+    int ret = scanner_scan(s, &t, &eol_encountered, &line);
     ASSERT_EQ(ret, 99);
 }
 
@@ -135,7 +137,7 @@ class scanner_scanning_valid_sourcefile : public ::testing::Test {
 TEST_F(scanner_scanning_valid_sourcefile, single_scan_call) {
     bool eol_encountered = false;
     int line = 0;
-    int ret = scanner_scan(s, &t, &eol_encountered, line);
+    int ret = scanner_scan(s, &t, &eol_encountered, &line);
     ASSERT_EQ(ret, 0);
 }
 
@@ -144,7 +146,7 @@ TEST_F(scanner_scanning_valid_sourcefile, scan_until_eof) {
     int line = 0;
     bool eol_encountered = false;
     do {
-        ret = scanner_scan(s, &t, &eol_encountered, line);
+        ret = scanner_scan(s, &t, &eol_encountered, &line);
         if (ret != EOF)
             ASSERT_EQ(ret, 0);
     } while (ret != EOF);


### PR DESCRIPTION
added int line to functions scanner_scan and scanner_skip_whitespaces_comments. It is used to track how many lines does compiled file have. When error in compilation occurs number of the line where error occured will be stored in int line. Also eddited tests in testunit so it suits new definition of scanner_scan.