### PR TITLE
differ literals from identifiers

### DIFF
--- a/src/scanner-private.c
+++ b/src/scanner-private.c
@@ -114,19 +114,19 @@ int scan_num_lit(scanner_t *s, token_t *t) {
     break;
 
   case '.':
-    t->type = FLOAT64;
+    t->type = FLOAT64_LIT;
     s->state = q7;
     return 0;
     break;
 
   case 'e':
-    t->type = FLOAT64;
+    t->type = FLOAT64_LIT;
     s->state = q8;
     return 0;
     break;
 
   case 'E':
-    t->type = FLOAT64;
+    t->type = FLOAT64_LIT;
     s->state = q8;
     return 0;
     break;
@@ -286,7 +286,7 @@ int innit_scan(scanner_t *s, token_t *t) {
 
         case '1': case '2': case '3': case '4': case '5': 
         case '6': case '7': case '8': case '9':
-          t->type = INT;
+          t->type = INT_LIT;
           s->state = f14;
           break;
 
@@ -300,7 +300,7 @@ int innit_scan(scanner_t *s, token_t *t) {
           break;
 
         case '"':
-          t->type = STRING;
+          t->type = STRING_LIT;
           s->state = q3;
 
           break;

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -136,14 +136,14 @@ int scanner_scan(scanner_t *s, token_t *t, bool *eol_encountered) {
 
        case f15:
         if ((s->character == 'e') || (s->character == 'E')) {
-          t->type = FLOAT64;
+          t->type = FLOAT64_LIT;
           s->state = q8;
         } else if (s->character == '.') {   //0.X
-          t->type = FLOAT64;
+          t->type = FLOAT64_LIT;
           s->state = q7;
         } else {
           ungetc(s->character, s->file);
-          t->type = INT;
+          t->type = INT_LIT;
           s->state = STOP;
         }
 

--- a/src/token.c
+++ b/src/token.c
@@ -23,15 +23,15 @@ void token_set_attribute(token_t *t, string str) {
     double tmp_d;
 
     switch (t->type) {
-        case STRING:
+        case STRING_LIT:
             strInit(&t->attribute.str_val);       
             strCopyString(&t->attribute.str_val, &str);
             break;
-        case INT:
+        case INT_LIT:
             tmp_int = atol((&str)->str);
             t->attribute.int_val = tmp_int;
             break;
-        case FLOAT64:
+        case FLOAT64_LIT:
             tmp_d = atof((&str)->str);
             t->attribute.float_val = tmp_d;
             break;


### PR DESCRIPTION
Changed wrongly set token types from identifiers to literals, because we kinda forgot about it in the previous versions.