### PR TITLE
Makefiles: Create zip archive conforming FIT standards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,8 @@
 # 24/09/2020
 
 export SHELL := /usr/bin/env sh
-export CC = /usr/bin/env gcc
-export CFLAGS = -std=c99 -g -Wall -Wextra
 export NAME = ifj20compiler
+export ZIPNAME = xfilip46.zip
 
 export PROJECT_DIR := $(shell pwd)
 export BUILD_DIR := $(PROJECT_DIR)/build
@@ -32,11 +31,13 @@ teste2e: all
 	@bats ./tests/e2e
 
 zip:
-	@zip xcoders69.zip Makefile src/*.c src/*.h src/Makefile
+	@mkdir -p $(BUILD_DIR)
+	@cd src; zip $(ZIPNAME) ./*.c ./*.h ./Makefile; mv $(ZIPNAME) ../
 
 clean:
-	@rm -f *.zip
+	@rm -f $(ZIPNAME)
 	@rm -f -r $(BUILD_DIR)
+	@rm -f src/$(NAME) src/*.o
 
 help:
 	@echo "make"

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,8 +3,16 @@
 # FIT BUT
 # 24/09/2020
 
+export CC = /usr/bin/env gcc
+export CFLAGS = -std=c99 -g -Wall -Wextra
+
 ifeq (0, ${MAKELEVEL})
-$(error invoke "make" from the root build directory)
+export SHELL := /usr/bin/env sh
+export NAME = ifj20compiler
+
+export TARGET := $(NAME)
+export OBJECTS_DIR := $(shell pwd)
+CFLAGS += -DNDEBUG
 endif
 
 public_sources = \


### PR DESCRIPTION
This does several things to achieve the goal mentioned in the title:

- Move definition of CC and CFLAGS to src/Makefile
- Allow direct execution of src/Makefile
- Add enough info in Makefile into src/Makefile to make it capable of
  handling the project compilation
- Add -DNDEBUG flag when src/Makefile is executed directly
- Do some shell trickery in 'zip' target to achieve the desired result
- Create a ZIPNAME variable to store the name of the final zip