### PR TITLE
Restructure debug functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Ignore the build folder
 build/
+# Ignore the binary file in /src (needs to be changed if filename changes)
+src/ifj20compiler
 
 # Prerequisites
 *.d

--- a/src/Makefile
+++ b/src/Makefile
@@ -60,3 +60,7 @@ $(TARGET): $(compiler_objects)
 	$(CC) -o $(TARGET) $^ $(LDFLAGS)
 $(compiler_objects): $(OBJECTS_DIR)/%.o: %.c
 	$(CC) $(CFLAGS) -c $< -o $@
+
+clean:
+	# remove the bin and object files
+	rm -f $(NAME) *.o

--- a/src/debug.c
+++ b/src/debug.c
@@ -1,26 +1,10 @@
 /**
  * @file debug.c
  * @author Marek Filip (xfilip46, Wecros), FIT BUT 
- * @date 12/11/2020
+ * @date 13/11/2020
  * @brief File holding debug function definitions.
  */
 
 #include "debug.h"
 
-void debug_lit_value(token_t t) {
-  if (token_is_lit(t.type)) {
-    switch (t.type) {
-      case STRING_LIT:
-        debug("Got VALUE: %s", strGetStr(&t.attribute.str_val));
-        break;
-      case FLOAT64_LIT:
-        debug("Got VALUE: %g", t.attribute.float_val);
-        break;
-      case INT_LIT:
-        debug("Got VALUE: %ld", t.attribute.int_val);
-        break;
-      default:
-        break;
-    }
-  }
-}
+extern void debug_lit_value(token_t t);

--- a/src/debug.h
+++ b/src/debug.h
@@ -9,9 +9,9 @@
  */
 
 /* debug.h
- * Zed A. Shaw, Ondřej Míchal <xmicha80>
+ * Zed A. Shaw, Ondřej Míchal <xmicha80>, Marek Filip <xfilip46>
  * FIT BUT
- * 05/11/2020
+ * 13/11/2020
  */
 
 #ifndef __DEBUG_H__
@@ -20,9 +20,16 @@
 #include <stdio.h>
 #include "token.h"
 
-#ifdef NDEBUG
+#ifdef NDEBUG // if NDEBUG -> don't debug
+// use this macro to silence unused parameter warning when compiling with NDEBUG
+#define unused(x) ((void) x)
+
 #define debug(M, ...)
 #define debug_entry()
+inline void debug_lit_value(token_t t) {
+  unused(t);
+}
+
 #else
 #define debug(M, ...) fprintf(stderr, "[DEBUG] %s:%d: " M "\n",\
         __FILE__, __LINE__, ##__VA_ARGS__)
@@ -32,8 +39,25 @@
 
 /**
  * @brief Debug the literal value of a literal.
+ * @description Inline debugging function.
  */
-void debug_lit_value(token_t t);
+inline void debug_lit_value(token_t t) {
+  if (token_is_lit(t.type)) {
+    switch (t.type) {
+      case STRING_LIT:
+        debug("Got VALUE: %s", strGetStr(&t.attribute.str_val));
+        break;
+      case FLOAT64_LIT:
+        debug("Got VALUE: %g", t.attribute.float_val);
+        break;
+      case INT_LIT:
+        debug("Got VALUE: %ld", t.attribute.int_val);
+        break;
+      default:
+        break;
+    }
+  }
+}
 #endif
 
 #endif // __DEBUG_H__

--- a/src/error.c
+++ b/src/error.c
@@ -29,6 +29,9 @@ void error_exit(unsigned error_code, const char* fmt, ...) {
 }
 
 void throw_syntax_error(token_type type, int line) {
+  #ifdef NDEBUG
+  unused(type);  // silence the unused-parameter warning
+  #endif
   debug("Token got: %s\n", token_get_type_string(type));
   error_exit(ERROR_SYNTAX, "Syntax error at line %d!\n", line);
 }


### PR DESCRIPTION
Fix support for NDEBUG flag for debug.c/.h. All debugging functions (not
macros) will be inline functions defined in debug.h with their inline
definition in debug.c.

Add 'unused' macro to silence compiler warning about unused-parameters.

Add clean target to src/Makefile if needed. (I like it for convenience)
Add src/ifj20compiler to .gitignore