### PR TITLE
Move global definitions to local scope

### DIFF
--- a/src/global.c
+++ b/src/global.c
@@ -13,9 +13,6 @@
  * @brief Definitions of the global variables of global.h
  */
 symtable_t *keywords_symtable;
-token_t lookahead;
-scanner_t *scanner;
-bool eol_encountered;
 
 int global_init() {
   debug_entry();

--- a/src/global.h
+++ b/src/global.h
@@ -20,21 +20,6 @@
  */
 extern symtable_t *keywords_symtable;
 
-/**
- * Global tracker of the lookahead token.
- */
-extern token_t lookahead;
-
-/**
- * Global tracker of the eol encountered flag.
- */
-extern bool eol_encountered;
-
-/**
- * Global tracker of the scanner struct.
- */
-extern scanner_t *scanner;
-
 struct keyword {
   char lit[20];
   token_type type;

--- a/src/main.c
+++ b/src/main.c
@@ -82,8 +82,8 @@ int main(int argc, char *argv[]) {
     return ERROR_INTERNAL;
   }
 
-  scanner = scanner_new(f);
-  parser_start();
+  scanner_t *scanner = scanner_new(f);
+  parser_start(scanner);
 
   scanner_free(scanner);
   fclose(f);

--- a/src/parser.c
+++ b/src/parser.c
@@ -19,6 +19,15 @@
 #include "str.h"
 
 
+// scanner local to the parser
+scanner_t *scanner;
+
+// next token to look at
+token_t lookahead;
+
+// tracker to tell us if an eol was scanned
+bool eol_encountered;
+
 // track the current line number
 int line = 1;
 
@@ -107,8 +116,10 @@ void parser_match_ident(char *ident_name) {
 /* MAIN RULES                                                               */
 /* ------------------------------------------------------------------------ */
 
-void parser_start() {
+void parser_start(scanner_t *scanner_main) {
   debug_entry();
+
+  scanner = scanner_main;
 
   // move the lookahead to the first lexeme
   parser_move();


### PR DESCRIPTION
Globals in question: lookahead, eol_encountered, scanner.
All of these were made local to parser.c