### PR TITLE
add zero-case scenarios to lexical e2e tests

### DIFF
--- a/samples/lexical-tests/float10.go
+++ b/samples/lexical-tests/float10.go
@@ -1,0 +1,9 @@
+// Hello World example in IFJ20
+// run it on Merlin by: go run hello.go ifj20.go
+
+package main
+
+func main() {
+  a := 0000.5
+  print("Hello from IFJ20", "\n")
+}

--- a/samples/lexical-tests/float11.go
+++ b/samples/lexical-tests/float11.go
@@ -1,0 +1,9 @@
+// Hello World example in IFJ20
+// run it on Merlin by: go run hello.go ifj20.go
+
+package main
+
+func main() {
+  a := 00.2147483646
+  print("Hello from IFJ20", "\n")
+}

--- a/samples/lexical-tests/float9.go
+++ b/samples/lexical-tests/float9.go
@@ -1,0 +1,9 @@
+// Hello World example in IFJ20
+// run it on Merlin by: go run hello.go ifj20.go
+
+package main
+
+func main() {
+  a := 00.0005E
+  print("Hello from IFJ20", "\n")
+}

--- a/samples/lexical-tests/integer1.go
+++ b/samples/lexical-tests/integer1.go
@@ -1,0 +1,9 @@
+// Hello World example in IFJ20
+// run it on Merlin by: go run hello.go ifj20.go
+
+package main
+
+func main() {
+  a := 00
+  print("Hello from IFJ20", "\n")
+}

--- a/samples/lexical-tests/integer2.go
+++ b/samples/lexical-tests/integer2.go
@@ -1,0 +1,9 @@
+// Hello World example in IFJ20
+// run it on Merlin by: go run hello.go ifj20.go
+
+package main
+
+func main() {
+  a := 01
+  print("Hello from IFJ20", "\n")
+}

--- a/samples/lexical-tests/integer3.go
+++ b/samples/lexical-tests/integer3.go
@@ -1,0 +1,9 @@
+// Hello World example in IFJ20
+// run it on Merlin by: go run hello.go ifj20.go
+
+package main
+
+func main() {
+  a := 0005
+  print("Hello from IFJ20", "\n")
+}

--- a/samples/lexical-tests/integer4.go
+++ b/samples/lexical-tests/integer4.go
@@ -1,0 +1,9 @@
+// Hello World example in IFJ20
+// run it on Merlin by: go run hello.go ifj20.go
+
+package main
+
+func main() {
+  a := 000000000000987
+  print("Hello from IFJ20", "\n")
+}

--- a/samples/lexical-tests/integer5.go
+++ b/samples/lexical-tests/integer5.go
@@ -1,0 +1,9 @@
+// Hello World example in IFJ20
+// run it on Merlin by: go run hello.go ifj20.go
+
+package main
+
+func main() {
+  a := 02147483646
+  print("Hello from IFJ20", "\n")
+}

--- a/samples/lexical-tests/integer6.go
+++ b/samples/lexical-tests/integer6.go
@@ -1,0 +1,9 @@
+// Hello World example in IFJ20
+// run it on Merlin by: go run hello.go ifj20.go
+
+package main
+
+func main() {
+  a := 05E
+  print("Hello from IFJ20", "\n")
+}

--- a/samples/lexical-tests/integer7.go
+++ b/samples/lexical-tests/integer7.go
@@ -1,0 +1,9 @@
+// Hello World example in IFJ20
+// run it on Merlin by: go run hello.go ifj20.go
+
+package main
+
+func main() {
+  a := 007E56
+  print("Hello from IFJ20", "\n")
+}

--- a/tests/e2e/002-lexical.bats
+++ b/tests/e2e/002-lexical.bats
@@ -12,6 +12,34 @@ lexical_samples="$samples/lexical-tests"
   run_compiler $ERROR_LEXICAL $lexical_samples/excl_mark.go
 }
 
+@test "Lexical analysis - integer1" {
+	run_compiler $ERROR_LEXICAL $lexical_samples/integer1.go
+}
+
+@test "Lexical analysis - integer2" {
+	run_compiler $ERROR_LEXICAL $lexical_samples/integer2.go
+}
+
+@test "Lexical analysis - integer3" {
+	run_compiler $ERROR_LEXICAL $lexical_samples/integer3.go
+}
+
+@test "Lexical analysis - integer4" {
+	run_compiler $ERROR_LEXICAL $lexical_samples/integer4.go
+}
+
+@test "Lexical analysis - integer5" {
+	run_compiler $ERROR_LEXICAL $lexical_samples/integer5.go
+}
+
+@test "Lexical analysis - integer6" {
+	run_compiler $ERROR_LEXICAL $lexical_samples/integer6.go
+}
+
+@test "Lexical analysis - integer7" {
+	run_compiler $ERROR_LEXICAL $lexical_samples/integer7.go
+}
+
 @test "Lexical analysis - float1" {
   run_compiler $ERROR_LEXICAL $lexical_samples/float1.go
 }
@@ -42,6 +70,18 @@ lexical_samples="$samples/lexical-tests"
 
 @test "Lexical analysis - float8" {
   run_compiler $ERROR_LEXICAL $lexical_samples/float8.go
+}
+
+@test "Lexical analysis - float9" {
+  run_compiler $ERROR_LEXICAL $lexical_samples/float9.go
+}
+
+@test "Lexical analysis - float10" {
+  run_compiler $ERROR_LEXICAL $lexical_samples/float10.go
+}
+
+@test "Lexical analysis - float11" {
+  run_compiler $ERROR_LEXICAL $lexical_samples/float11.go
 }
 
 @test "Lexical analysis - string1" {


### PR DESCRIPTION
I made a few lexical end to end tests with integer and float values that should test our current problem with 0. Currently they fail, because the fix has not been implemented yet but once it is, we'll have something to test it against.