### PR TITLE
unite the coding and file header style

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,6 @@
 # Makefile
 # Ondřej Míchal <xmicha80>
-# FIT BUT
+# Implementace překladače imperativního jazyka IFJ20.
 # 24/09/2020
 
 export CC = /usr/bin/env gcc

--- a/src/debug.c
+++ b/src/debug.c
@@ -1,8 +1,9 @@
 /**
  * @file debug.c
- * @author Marek Filip (xfilip46, Wecros), FIT BUT 
- * @date 13/11/2020
+ * @author Marek Filip <xfilip46>
  * @brief File holding debug function definitions.
+ * @details Implementace překladače imperativního jazyka IFJ20.
+ * @date 13/11/2020
  */
 
 #include "debug.h"

--- a/src/debug.h
+++ b/src/debug.h
@@ -13,6 +13,8 @@
  * @author Zed A. Shaw
  * @author Ondřej Míchal <xmicha80>
  * @author Marek Filip <xfilip46>
+ * @brief File holding debug functions
+ * @details Implementace překladače imperativního jazyka IFJ20.
  * @date 13/11/2020
  */
 
@@ -29,7 +31,7 @@
 #define debug(M, ...)
 #define debug_entry()
 inline void debug_lit_value(token_t t) {
-  unused(t);
+    unused(t);
 }
 
 #else
@@ -44,21 +46,21 @@ inline void debug_lit_value(token_t t) {
  * @description Inline debugging function.
  */
 inline void debug_lit_value(token_t t) {
-  if (token_is_lit(t.type)) {
-    switch (t.type) {
-      case STRING_LIT:
-        debug("Got VALUE: %s", strGetStr(&t.attribute.str_val));
-        break;
-      case FLOAT64_LIT:
-        debug("Got VALUE: %g", t.attribute.float_val);
-        break;
-      case INT_LIT:
-        debug("Got VALUE: %ld", t.attribute.int_val);
-        break;
-      default:
-        break;
+    if (token_is_lit(t.type)) {
+        switch (t.type) {
+            case STRING_LIT:
+                debug("Got VALUE: %s", strGetStr(&t.attribute.str_val));
+                break;
+            case FLOAT64_LIT:
+                debug("Got VALUE: %g", t.attribute.float_val);
+                break;
+            case INT_LIT:
+                debug("Got VALUE: %ld", t.attribute.int_val);
+                break;
+            default:
+                break;
+        }
     }
-  }
 }
 #endif
 

--- a/src/error.c
+++ b/src/error.c
@@ -1,8 +1,9 @@
 /**
  * @file error.c
- * @author Marek Filip (xfilip46, Wecros), FIT BUT
+ * @author Marek Filip <xfilip46>
+ * @brief Error function definitions.
+ * @details Implementace překladače imperativního jazyka IFJ20.
  * @date 10/11/2020
- * @brief Error functions definitions.
  */
 
 #include <stdio.h>
@@ -15,36 +16,36 @@
 #include "token.h"
 
 void error_exit(unsigned error_code, const char* fmt, ...) {
-  va_list ap;
-  va_start(ap, fmt);
+    va_list ap;
+    va_start(ap, fmt);
 
-  fputs("ERROR: ", stderr);
-  vfprintf(stderr, fmt, ap);
+    fputs("ERROR: ", stderr);
+    vfprintf(stderr, fmt, ap);
 
-  va_end(ap);
+    va_end(ap);
 
-  // FIXME: deallocation of resources
+    // FIXME: deallocation of resources
 
-  exit(error_code);
+    exit(error_code);
 }
 
 void throw_syntax_error(token_type type, int line) {
-  #ifdef NDEBUG
-  unused(type);  // silence the unused-parameter warning
-  #endif
-  debug("Token got: %s\n", token_get_type_string(type));
-  error_exit(ERROR_SYNTAX, "Syntax error at line %d!\n", line);
+    #ifdef NDEBUG
+    unused(type);  // silence the unused-parameter warning
+    #endif
+    debug("Token got: %s\n", token_get_type_string(type));
+    error_exit(ERROR_SYNTAX, "Syntax error at line %d!\n", line);
 }
 
 void throw_lex_error(int line) {
-  error_exit(ERROR_LEXICAL, "Lexical error at line %d!\n", line);
+    error_exit(ERROR_LEXICAL, "Lexical error at line %d!\n", line);
 }
 
 void throw_internal_error(int line) {
-  error_exit(ERROR_INTERNAL, "Internal error at line %d!\n", line);
+    error_exit(ERROR_INTERNAL, "Internal error at line %d!\n", line);
 }
 
 void success_exit() {
-  fprintf(stderr, "Sucesfully compiled.\n");
-  exit(SUCCESS);
+    fprintf(stderr, "Sucesfully compiled.\n");
+    exit(SUCCESS);
 }

--- a/src/error.h
+++ b/src/error.h
@@ -1,7 +1,9 @@
-/**
+/** 
  * @file error.h
- * @author Vojtech Fiala <xfiala61>
+ * @author Vojtěch Fiala <xfiala61>
  * @author Marek Filip <xfilip46>
+ * @brief Error codes and function declarations
+ * @details Implementace překladače imperativního jazyka IFJ20.
  * @date 10/11/2020
  */
 

--- a/src/global.c
+++ b/src/global.c
@@ -1,7 +1,9 @@
-/* global.c
- * Ondřej Míchal <xmicha80>
- * FIT BUT
- * 11/11/2020
+/**
+ * @file global.c
+ * @author Ondřej Míchal <xmicha80>
+ * @brief Global variable declarations
+ * @details Implementace překladače imperativního jazyka IFJ20.
+ * @date 11/11/2020
  */
 
 #include "debug.h"
@@ -15,39 +17,39 @@
 symtable_t *keywords_symtable;
 
 int global_init() {
-  debug_entry();
+    debug_entry();
 
-  // Inicialize global hashtable (resp. symtable) of keywords
-  struct keyword keywords[] = { 
-    { "else", ELSE },
-    { "float64", FLOAT64 },
-    { "for", FOR },
-    { "func", FUNC },
-    { "if", IF },
-    { "int" , INT },
-    { "package", PACKAGE },
-    { "return", RETURN },
-    { "string", STRING }
-  };
-  const int NUM_OF_KEYWORDS = sizeof(keywords) / sizeof(struct keyword);
+    // Inicialize global hashtable (resp. symtable) of keywords
+    struct keyword keywords[] = { 
+        { "else", ELSE },
+        { "float64", FLOAT64 },
+        { "for", FOR },
+        { "func", FUNC },
+        { "if", IF },
+        { "int" , INT },
+        { "package", PACKAGE },
+        { "return", RETURN },
+        { "string", STRING }
+    };
+    const int NUM_OF_KEYWORDS = sizeof(keywords) / sizeof(struct keyword);
 
-  keywords_symtable = symtable_new();
-  if (keywords_symtable == NULL)
-    return 1;
+    keywords_symtable = symtable_new();
+    if (keywords_symtable == NULL)
+        return 1;
 
-  for (int i = 0; i < NUM_OF_KEYWORDS; i++) {
-    struct keyword keyword = keywords[i];
-    // Add keyword to symtable (only key)
-    symtable_iterator_t it = symtable_lookup_add(keywords_symtable, keyword.lit);
-    if (!symtable_iterator_valid(it))
-      return 1;
+    for (int i = 0; i < NUM_OF_KEYWORDS; i++) {
+        struct keyword keyword = keywords[i];
+        // Add keyword to symtable (only key)
+        symtable_iterator_t it = symtable_lookup_add(keywords_symtable, keyword.lit);
+        if (!symtable_iterator_valid(it))
+            return 1;
 
-    // Create a new token for a keyword and add it to the key in symtable
-    token_t t;
-    t.type = keyword.type;
-    t.attribute.sym_key = keyword.lit;
-    symtable_iterator_set_value(it, t);
-  }
+        // Create a new token for a keyword and add it to the key in symtable
+        token_t t;
+        t.type = keyword.type;
+        t.attribute.sym_key = keyword.lit;
+        symtable_iterator_set_value(it, t);
+    }
 
-  return 0;
+    return 0;
 }

--- a/src/global.h
+++ b/src/global.h
@@ -1,10 +1,10 @@
 /**
  * @file global.h 
- * @author Marek Filip <xfilip46, Wecros>
+ * @author Marek Filip <xfilip46>
  * @author Ondřej Míchal <xmicha80>
- * FIT BUT 
- * @date 10/11/2020
  * @brief Header file for global variable definitions.
+ * @details Implementace překladače imperativního jazyka IFJ20.
+ * @date 10/11/2020
  */
 
 #ifndef __GLOBAL_H__
@@ -21,8 +21,8 @@
 extern symtable_t *keywords_symtable;
 
 struct keyword {
-  char lit[20];
-  token_type type;
+    char lit[20];
+    token_type type;
 };
 
 /**

--- a/src/main.c
+++ b/src/main.c
@@ -1,6 +1,9 @@
-/* main.c
- * Ondřej Míchal <xmicha80>
- * 24/09/2020
+/** 
+ * @file main.c
+ * @author Ondřej Míchal <xmicha80>
+ * @brief Main file that runs the whole program 
+ * @details Implementace překladače imperativního jazyka IFJ20.
+ * @date 24/09/2020
  */
 
 #include <stdlib.h>
@@ -15,78 +18,77 @@
 const char *program_name = "ifj20compiler";
 
 typedef struct args {
-	char *input_file;
+    char *input_file;
 } args_t;
 
 void print_usage_hint() {
-  printf("See '%s --help' for usage.\n", program_name);
+    printf("See '%s --help' for usage.\n", program_name);
 }
 
 void print_help() {
-  printf("Usage: %s [options] file \n", program_name);
-  printf("\n");
-  printf("Options:\n");
-  printf("\t-h, --help\t\tshow help screen\n");
-  printf("\n");
-  printf("With no file, read standard input.\n");
+    printf("Usage: %s [options] file \n", program_name);
+    printf("\n");
+    printf("Options:\n");
+    printf("\t-h, --help\t\tshow help screen\n");
+    printf("\n");
+    printf("With no file, read standard input.\n");
 
-  exit(SUCCESS);
+    exit(SUCCESS);
 }
 
 void handle_args(int argc, char *argv[], args_t *args) {
-  for (int i = 1; i < argc; i++) {
-    // TODO: Add --debug option to enable debugging macros
-    if (strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0)
-      print_help();
-    else if (strncmp(argv[i], "-", 1) == 0) {
-      // Handle unrecognized options
-      fprintf(stderr, "%s: unrecognized option %s\n", program_name, argv[i]);
-      print_usage_hint();
-      exit(ERROR_INTERNAL);
+    for (int i = 1; i < argc; i++) {
+        // TODO: Add --debug option to enable debugging macros
+        if (strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0) {
+            print_help();
+        } else if (strncmp(argv[i], "-", 1) == 0) {
+            // Handle unrecognized options
+            fprintf(stderr, "%s: unrecognized option %s\n", program_name, argv[i]);
+            print_usage_hint();
+            exit(ERROR_INTERNAL);
+        } else {
+            if (args->input_file == NULL) {
+                args->input_file = argv[i];
+            } else {
+                fprintf(stderr, "%s: only one input file is accepted\n", program_name);
+                print_usage_hint();
+                exit(ERROR_INTERNAL);
+            }
+        }
     }
-    else {
-      if (args->input_file == NULL)
-        args->input_file = argv[i];
-      else {
-        fprintf(stderr, "%s: only one input file is accepted\n", program_name);
-        print_usage_hint();
-        exit(ERROR_INTERNAL);
-      }
-    }
-  }
 
-  if (args->input_file == NULL)
-    args->input_file = "-";
+    if (args->input_file == NULL)
+        args->input_file = "-";
 }
 
 int main(int argc, char *argv[]) {
-  args_t args = { NULL, };
-  handle_args(argc, argv, &args);
+    args_t args = { NULL, };
+    handle_args(argc, argv, &args);
 
-  FILE *f;
+    FILE *f;
 
-  if (strcmp(args.input_file, "-") == 0)
-    f = stdin;
-  else {
-    f = fopen(args.input_file, "r");
+    if (strcmp(args.input_file, "-") == 0) {
+        f = stdin;
+    } else {
+        f = fopen(args.input_file, "r");
 
-    if (f == NULL) {
-      fprintf(stderr, "%s: there was an error while opening file \"%s\"\n", program_name, args.input_file);
-      print_usage_hint();
-      return ERROR_INTERNAL;
+        if (f == NULL) {
+            fprintf(stderr, "%s: there was an error while opening file \"%s\"\n", program_name, args.input_file);
+            print_usage_hint();
+            return ERROR_INTERNAL;
+        }
     }
-  }
 
-  if (global_init() != 0) {
-    fprintf(stderr, "%s: there was an error during compiler's inicialization\n", program_name);
-    return ERROR_INTERNAL;
-  }
+    if (global_init() != 0) {
+        fprintf(stderr, "%s: there was an error during compiler's inicialization\n", program_name);
+        return ERROR_INTERNAL;
+    }
 
-  scanner_t *scanner = scanner_new(f);
-  parser_start(scanner);
+    scanner_t *scanner = scanner_new(f);
+    parser_start(scanner);
 
-  scanner_free(scanner);
-  fclose(f);
+    scanner_free(scanner);
+    fclose(f);
 
-  return SUCCESS;
+    return SUCCESS;
 }

--- a/src/parser.c
+++ b/src/parser.c
@@ -1,9 +1,9 @@
 /**
  * @file parser.c
- * @author Marek Filip (xfilip46, Wecros), FIT BUT 
+ * @author Marek Filip <xfilip46>
+ * @brief Parser part of ifj20 compiler - the heart of the compiler.
+ * @details Implementace překladače imperativního jazyka IFJ20.
  * @date 10/11/2020
- * @brief Parser part of ifj20 compiler.
- * @details Parser is the heart of the compiler and its most difficult part.
  */
 
 #include <stdio.h>
@@ -46,70 +46,70 @@ int return_code = 0;
 // TODO: make eol rules
 
 void parser_move() {
-  debug_entry();
+    debug_entry();
 
-  eol_encountered = false;
-  // move the lookahead
-  return_code = scanner_scan(scanner, &lookahead, &eol_encountered, &line);
+    eol_encountered = false;
+    // move the lookahead
+    return_code = scanner_scan(scanner, &lookahead, &eol_encountered, &line);
 
-  // TODO: make sure all return cases are handled here
+    // TODO: make sure all return cases are handled here
 
-  if (return_code == ERROR_LEXICAL) {
-    throw_lex_error(line);
-  } else if (return_code == ERROR_INTERNAL) {
-    throw_internal_error(line);
-  } else if (return_code == EOF) {
-    eof_found = true;
-  }
+    if (return_code == ERROR_LEXICAL) {
+        throw_lex_error(line);
+    } else if (return_code == ERROR_INTERNAL) {
+        throw_internal_error(line);
+    } else if (return_code == EOF) {
+        eof_found = true;
+    }
 
-  if (lookahead.type == INVALID && return_code != EOF) {
-    fprintf(stderr, "!!! INVALID TOKEN !!!\n");
-    throw_lex_error(line);
-  }
+    if (lookahead.type == INVALID && return_code != EOF) {
+        fprintf(stderr, "!!! INVALID TOKEN !!!\n");
+        throw_lex_error(line);
+    }
 
-  required_eol = false;
+    required_eol = false;
 }
 
 void parser_match(token_type t) {
-  debug_entry();
-  if (lookahead.type == t) {
-    debug("Matched type: %s", token_get_type_string(t));
-    debug_lit_value(lookahead);
+    debug_entry();
+    if (lookahead.type == t) {
+        debug("Matched type: %s", token_get_type_string(t));
+        debug_lit_value(lookahead);
 
-    // EOL CHECKING
-    debug("got eol? %d no_eol? %d required_eol? %d", eol_encountered, no_eol, required_eol);
-    if (eol_encountered && no_eol) {
-      fprintf(stderr, "Wrong EOL placement!\n");
-      throw_syntax_error(lookahead.type, line);
-    } 
-    else if (!eol_encountered && required_eol) {
-      fprintf(stderr, "EOL should be here!\n");
-      throw_syntax_error(lookahead.type, line);
+        // EOL CHECKING
+        debug("got eol? %d no_eol? %d required_eol? %d", eol_encountered, no_eol, required_eol);
+        if (eol_encountered && no_eol) {
+            fprintf(stderr, "Wrong EOL placement!\n");
+            throw_syntax_error(lookahead.type, line);
+        } else if (!eol_encountered && required_eol) {
+            fprintf(stderr, "EOL should be here!\n");
+            throw_syntax_error(lookahead.type, line);
+        }
+
+        parser_move();  
+
+    } else {
+        debug("Expected type: %s", token_get_type_string(t));
+        debug("Got type: %s", token_get_type_string(lookahead.type));
+        debug_lit_value(lookahead);
+
+        throw_syntax_error(t, line);
     }
-
-    parser_move();
-  } else {
-    debug("Expected type: %s", token_get_type_string(t));
-    debug("Got type: %s", token_get_type_string(lookahead.type));
-    debug_lit_value(lookahead);
-
-    throw_syntax_error(t, line);
-  }
 }
 
 void parser_match_ident(char *ident_name) {
-  debug_entry();
-  if (lookahead.type == IDENT && strcmp(lookahead.attribute.sym_key, ident_name) == 0) {
-    debug("Matched type and string: %s, %s",
-        token_get_type_string(IDENT), ident_name);
-    parser_move();
-  } else {
-    debug("Expected type and ident name: %s, %s",
-        token_get_type_string(IDENT), ident_name);
-    debug("Got type and ident name: %s, %s",
-        token_get_type_string(IDENT), lookahead.attribute.sym_key);
-    throw_syntax_error(lookahead.type, line);
-  }
+    debug_entry();
+    if (lookahead.type == IDENT && strcmp(lookahead.attribute.sym_key, ident_name) == 0) {
+        debug("Matched type and string: %s, %s",
+            token_get_type_string(IDENT), ident_name);
+        parser_move();
+    } else {
+        debug("Expected type and ident name: %s, %s",
+            token_get_type_string(IDENT), ident_name);
+        debug("Got type and ident name: %s, %s",
+            token_get_type_string(IDENT), lookahead.attribute.sym_key);
+        throw_syntax_error(lookahead.type, line);
+    }
 }
 
 /* ------------------------------------------------------------------------ */
@@ -117,134 +117,134 @@ void parser_match_ident(char *ident_name) {
 /* ------------------------------------------------------------------------ */
 
 void parser_start(scanner_t *scanner_main) {
-  debug_entry();
+    debug_entry();
 
-  scanner = scanner_main;
+    scanner = scanner_main;
 
-  // move the lookahead to the first lexeme
-  parser_move();
+    // move the lookahead to the first lexeme
+    parser_move();
 
-  parser_prolog();  
-  parser_funcs();
+    parser_prolog();  
+    parser_funcs();
 }
 
 void parser_prolog() {
-  debug_entry();
-  parser_match(PACKAGE);
-  parser_match_ident("main"); 
+    debug_entry();
+    parser_match(PACKAGE);
+    parser_match_ident("main"); 
 }
 
 void parser_funcs() {
-  debug_entry();
+    debug_entry();
 
-  if (eof_found) {
-    fprintf(stderr, "EOF encountered, stopping syntax analysis...\n");
-    fprintf(stderr, "line: %d\n", line);
-    success_exit();
-  }
+    if (eof_found) {
+        fprintf(stderr, "EOF encountered, stopping syntax analysis...\n");
+        fprintf(stderr, "line: %d\n", line);
+        success_exit();
+    }
 
-  // if FUNC not found, apply eps-rule
-  if (lookahead.type == FUNC) {
-      // function decleration
-      parser_match(FUNC);
-      no_eol = true;
-      parser_match(IDENT);
-      parser_params();
-      parser_r_params();
-      parser_block();
-      parser_funcs();
-  }
-  // apply eps-rule
+    // if FUNC not found, apply eps-rule
+    if (lookahead.type == FUNC) {
+        // function decleration
+        parser_match(FUNC);
+        no_eol = true;
+        parser_match(IDENT);
+        parser_params();
+        parser_r_params();
+        parser_block();
+        parser_funcs();
+    }
+    // apply eps-rule
 
-  if (!eof_found) {
-    // if EOF not found, throw syntax error, program should not end here.
-    throw_syntax_error();
-  }
+    if (!eof_found) {
+        // if EOF not found, throw syntax error, program should not end here.
+        throw_syntax_error();
+    }
 }
 
 void parser_stmts() {
-  debug_entry();
-  switch (lookahead.type) {
-    case IDENT:
-    case IF:
-    case FOR:
-    case RETURN:
-      parser_stmt();
-      parser_stmts();
-      break;
-    default:
-      // apply eps-rule
-      break;
-  }
+    debug_entry();
+    switch (lookahead.type) {
+        case IDENT:
+        case IF:
+        case FOR:
+        case RETURN:
+            parser_stmt();
+            parser_stmts();
+            break;
+        default:
+            // apply eps-rule
+            break;
+    }
 }
 
 void parser_stmt() {
-  debug_entry();
-  switch (lookahead.type) {
-    case IDENT:
-      // identifier found
-      parser_match(IDENT);
-      parser_id_first();
-      break;
-    case IF:
-      // if statement
-      parser_match(IF);
-      no_eol = true;
-      parser_expr();
-      parser_block();
-      parser_match(ELSE);
-      no_eol = true;
-      parser_block();
-      required_eol = true;
-      break;
-    case FOR:
-      // for loop
-      parser_match(FOR);
-      no_eol = true;
-      parser_optdef();
-      parser_match(SEMICOLON);
-      parser_expr();
-      parser_match(SEMICOLON);
-      parser_optassign();
-      parser_block();
-      required_eol = true;
-      break;
-    case RETURN:
-      // return statement
-      parser_return();
-      required_eol = true;
-      break;
-    default:
-      // no eps-rule -> throw syntax error
-      throw_syntax_error(lookahead.type, line);
-      break;
-  }
+    debug_entry();
+    switch (lookahead.type) {
+        case IDENT:
+            // identifier found
+            parser_match(IDENT);
+            parser_id_first();
+            break;
+        case IF:
+            // if statement
+            parser_match(IF);
+            no_eol = true;
+            parser_expr();
+            parser_block();
+            parser_match(ELSE);
+            no_eol = true;
+            parser_block();
+            required_eol = true;
+            break;
+        case FOR:
+            // for loop
+            parser_match(FOR);
+            no_eol = true;
+            parser_optdef();
+            parser_match(SEMICOLON);
+            parser_expr();
+            parser_match(SEMICOLON);
+            parser_optassign();
+            parser_block();
+            required_eol = true;
+            break;
+        case RETURN:
+            // return statement
+            parser_return();
+            required_eol = true;
+            break;
+        default:
+            // no eps-rule -> throw syntax error
+            throw_syntax_error(lookahead.type, line);
+            break;
+    }
 }
 
 void parser_id_first() {
-  debug_entry();
-  switch (lookahead.type) {
-    case DEFINE:
-      // variable definition
-      parser_vardef();
-      required_eol = true;
-      break;
-    case ASSIGN:
-    case COMMA:
-      // variable assign
-      parser_assign();
-      required_eol = true;
-      break;
-    case LPAREN:
-      // function call
-      parser_c_params();
-      required_eol = true;
-      break;
-    default:
-      // no eps-rule -> throw syntax error
-      throw_syntax_error(lookahead.type, line);
-      break;
-  }
+    debug_entry();
+    switch (lookahead.type) {
+        case DEFINE:
+            // variable definition
+            parser_vardef();
+            required_eol = true;
+            break;
+        case ASSIGN:
+        case COMMA:
+            // variable assign
+            parser_assign();
+            required_eol = true;
+            break;
+        case LPAREN:
+            // function call
+            parser_c_params();
+            required_eol = true;
+            break;
+        default:
+            // no eps-rule -> throw syntax error
+            throw_syntax_error(lookahead.type, line);
+            break;
+    }
 }
 
 /* ------------------------------------------------------------------------ */
@@ -252,29 +252,29 @@ void parser_id_first() {
 /* ------------------------------------------------------------------------ */
 
 void parser_type() {
-  debug_entry();
-  switch (lookahead.type) {
-    case INT:
-      parser_match(INT);
-      break; case FLOAT64:
-      parser_match(FLOAT64);
-      break;
-    case STRING:
-      parser_match(STRING);
-      break;
-    default:
-      // no eps-rule -> throw syntax error
-      throw_syntax_error(lookahead.type, line);
-      break;
-  }
+    debug_entry();
+    switch (lookahead.type) {
+        case INT:
+            parser_match(INT);
+            break; case FLOAT64:
+            parser_match(FLOAT64);
+            break;
+        case STRING:
+            parser_match(STRING);
+            break;
+        default:
+            // no eps-rule -> throw syntax error
+            throw_syntax_error(lookahead.type, line);
+            break;
+    }
 }
 
 void parser_block() {
-  debug_entry();
-  parser_match(LBRACE);
-  no_eol = false;
-  parser_stmts();
-  parser_match(RBRACE);
+    debug_entry();
+    parser_match(LBRACE);
+    no_eol = false;
+    parser_stmts();
+    parser_match(RBRACE);
 }
 
 /* ------------------------------------------------------------------------ */
@@ -282,136 +282,136 @@ void parser_block() {
 /* ------------------------------------------------------------------------ */
 
 void parser_params() {
-  debug_entry();
-  parser_match(LPAREN);
-  parser_params_n();
+    debug_entry();
+    parser_match(LPAREN);
+    parser_params_n();
 }
 
 void parser_params_n() {
-  debug_entry();
-  switch (lookahead.type) {
-    case IDENT:
-      parser_param();
-      parser_match(RPAREN);
-      break;
-    case RPAREN:
-      parser_match(RPAREN);
-      break;
-    default:
-      // no eps-rule -> throw syntax error
-      throw_syntax_error(line);
-      break;
-  } 
+    debug_entry();
+    switch (lookahead.type) {
+        case IDENT:
+            parser_param();
+            parser_match(RPAREN);
+            break;
+        case RPAREN:
+            parser_match(RPAREN);
+            break;
+        default:
+            // no eps-rule -> throw syntax error
+            throw_syntax_error(line);
+            break;
+    } 
 }
 
 void parser_param() {
-  debug_entry();
-  parser_match(IDENT);
-  parser_type();
-  parser_param_n();
-}
-
-void parser_param_n() {
-  debug_entry();
-  // if COMMA not found, apply eps-rule
-  if (lookahead.type == COMMA) {
-    parser_match(COMMA);
+    debug_entry();
     parser_match(IDENT);
     parser_type();
     parser_param_n();
-  }
-  // apply eps-rule
+}
+
+void parser_param_n() {
+    debug_entry();
+    // if COMMA not found, apply eps-rule
+    if (lookahead.type == COMMA) {
+        parser_match(COMMA);
+        parser_match(IDENT);
+        parser_type();
+        parser_param_n();
+    }
+    // apply eps-rule
 }
 
 void parser_r_params() {
-  debug_entry();
-  // if '(' not found, apply eps-rule
-  if (lookahead.type == LPAREN) {
-    parser_match(LPAREN);
-    parser_r_params_n();
-  } 
-  // apply eps-rule
+    debug_entry();
+    // if '(' not found, apply eps-rule
+    if (lookahead.type == LPAREN) {
+        parser_match(LPAREN);
+        parser_r_params_n();
+    } 
+    // apply eps-rule
 }
 
 void parser_r_params_n() {
-  debug_entry();
-  switch (lookahead.type) {
-    // depending on the case either put ')' or continue with params
-    case INT:
-    case FLOAT64:
-    case STRING:
-      parser_r_param();
-      parser_match(RPAREN);
-      break;
-    case RPAREN:
-      parser_match(RPAREN);
-      break;
-    default:
-      // no eps-rule -> throw syntax error
-      throw_syntax_error(lookahead.type, line);
-      break;
-  }
+    debug_entry();
+    switch (lookahead.type) {
+        // depending on the case either put ')' or continue with params
+        case INT:
+        case FLOAT64:
+        case STRING:
+            parser_r_param();
+            parser_match(RPAREN);
+            break;
+        case RPAREN:
+            parser_match(RPAREN);
+            break;
+        default:
+            // no eps-rule -> throw syntax error
+            throw_syntax_error(lookahead.type, line);
+            break;
+    }
 }
 
 void parser_r_param() {
-  debug_entry();
-  parser_type();
-  parser_r_param_n();
+    debug_entry();
+    parser_type();
+    parser_r_param_n();
 }
 
 void parser_r_param_n() {
-  debug_entry();
-  // if COMMA not found, apply eps-rule
-  if (lookahead.type == COMMA) {
-    parser_match(COMMA);
-    parser_type();
-    parser_r_param_n();
-  }
-  // apply eps-rule
+    debug_entry();
+    // if COMMA not found, apply eps-rule
+    if (lookahead.type == COMMA) {
+        parser_match(COMMA);
+        parser_type();
+        parser_r_param_n();
+    }
+    // apply eps-rule
 }
 
 void parser_c_params() {
-  debug_entry();
-  parser_match(LPAREN);
-  parser_c_params_n();
+    debug_entry();
+    parser_match(LPAREN);
+    parser_c_params_n();
 }
 
 void parser_c_params_n() {
-  debug_entry();
-  switch (lookahead.type) {
-    case LPAREN:
-    case INT_LIT:
-    case FLOAT64_LIT:
-    case STRING_LIT:
-    case IDENT:
-      parser_c_param();
-      parser_match(RPAREN);
-      break;
-    case RPAREN:
-      parser_match(RPAREN);
-      break;
-    default:
-      // no eps-rule -> throw syntax error
-      throw_syntax_error(lookahead.type, line);
-      break;
-  }
+    debug_entry();
+    switch (lookahead.type) {
+        case LPAREN:
+        case INT_LIT:
+        case FLOAT64_LIT:
+        case STRING_LIT:
+        case IDENT:
+            parser_c_param();
+            parser_match(RPAREN);
+            break;
+        case RPAREN:
+            parser_match(RPAREN);
+            break;
+        default:
+            // no eps-rule -> throw syntax error
+            throw_syntax_error(lookahead.type, line);
+            break;
+    }
 }
 
 void parser_c_param() {
-  debug_entry();
-  parser_expr();
-  parser_c_param_n();
+    debug_entry();
+    parser_expr();
+    parser_c_param_n();
 }
 
 void parser_c_param_n() {
-  debug_entry();
-  // if COMMA not found, apply eps-rule
-  if (lookahead.type == COMMA) {
-    parser_match(COMMA);
-    parser_expr();
-    parser_c_param_n();
-  }
-  // apply eps-rule
+    debug_entry();
+    // if COMMA not found, apply eps-rule
+    if (lookahead.type == COMMA) {
+        parser_match(COMMA);
+        parser_expr();
+        parser_c_param_n();
+    }
+    // apply eps-rule
 }
 
 /* ------------------------------------------------------------------------ */
@@ -419,44 +419,44 @@ void parser_c_param_n() {
 /* ------------------------------------------------------------------------ */
 
 void parser_vardef() {
-  debug_entry();
-  parser_match(DEFINE);
-  parser_expr();
+    debug_entry();
+    parser_match(DEFINE);
+    parser_expr();
 }
 
 void parser_assign() {
-  debug_entry();
-  parser_id_n();
-  parser_match(ASSIGN);
-  parser_exprs();
+    debug_entry();
+    parser_id_n();
+    parser_match(ASSIGN);
+    parser_exprs();
 }
 
 void parser_id_n() {
-  debug_entry();
-  // if COMMA not found, apply eps-rule
-  if (lookahead.type == COMMA) {
-    parser_match(COMMA);
-    parser_match(IDENT);
-    parser_id_n();
-  }
-  // apply eps-rule
+    debug_entry();
+    // if COMMA not found, apply eps-rule
+    if (lookahead.type == COMMA) {
+        parser_match(COMMA);
+        parser_match(IDENT);
+        parser_id_n();
+    }
+    // apply eps-rule
 }
 
 void parser_exprs() {
-  debug_entry();
-  parser_expr();
-  parser_expr_n();
+    debug_entry();
+    parser_expr();
+    parser_expr_n();
 }
 
 void parser_expr_n() {
-  debug_entry();
-  // if COMMA not found, apply eps-rule
-  if (lookahead.type == COMMA) {
-    parser_match(COMMA);
-    parser_expr();
-    parser_expr_n();
-  }
-  // apply eps-rule
+    debug_entry();
+    // if COMMA not found, apply eps-rule
+    if (lookahead.type == COMMA) {
+        parser_match(COMMA);
+        parser_expr();
+        parser_expr_n();
+    }
+    // apply eps-rule
 }
 
 /* ------------------------------------------------------------------------ */
@@ -464,23 +464,23 @@ void parser_expr_n() {
 /* ------------------------------------------------------------------------ */
 
 void parser_optdef() {
-  debug_entry();
-  // if IDENT not found, apply eps-rule
-  if (lookahead.type == IDENT) {
-    parser_match(IDENT);
-    parser_vardef();
-  }
-  // apply eps-rule
+    debug_entry();
+    // if IDENT not found, apply eps-rule
+    if (lookahead.type == IDENT) {
+        parser_match(IDENT);
+        parser_vardef();
+    }
+    // apply eps-rule
 }
 
 void parser_optassign() {
-  debug_entry();
-  // if IDENT not found, apply eps-rule
-  if (lookahead.type == IDENT) {
-    parser_match(IDENT);
-    parser_assign();
-  }
-  // apply eps-rule
+    debug_entry();
+    // if IDENT not found, apply eps-rule
+    if (lookahead.type == IDENT) {
+        parser_match(IDENT);
+        parser_assign();
+    }
+    // apply eps-rule
 }
 
 /* ------------------------------------------------------------------------ */
@@ -491,26 +491,26 @@ void parser_optassign() {
 // return
 // eps
 void parser_return() {
-  debug_entry();
-  parser_match(RETURN);  
-  parser_optexprs();
+    debug_entry();
+    parser_match(RETURN);  
+    parser_optexprs();
 }
 
 void parser_optexprs() {
-  debug_entry();
-  // optional expression depending on the type read
-  switch (lookahead.type) {
-    case LPAREN:
-    case INT_LIT:
-    case FLOAT64_LIT:
-    case STRING_LIT:
-    case IDENT:
-      parser_exprs();
-      break;
-    default:
-      // apply eps-rule
-      break;
-  }
+    debug_entry();
+    // optional expression depending on the type read
+    switch (lookahead.type) {
+        case LPAREN:
+        case INT_LIT:
+        case FLOAT64_LIT:
+        case STRING_LIT:
+        case IDENT:
+            parser_exprs();
+            break;
+        default:
+            // apply eps-rule
+            break;
+    }
 }
 
 /* ------------------------------------------------------------------------ */
@@ -518,59 +518,59 @@ void parser_optexprs() {
 /* ------------------------------------------------------------------------ */
 
 void parser_expr() {
-  // This parsing is only used for the 0th submission
-  parser_rel();
+    // This parsing is only used for the 0th submission
+    parser_rel();
 }
 
 /* THIS WILL BE LEFT OUT IN THE FINAL PARSER */
 
 /* Helper functions */
 bool is_relop(token_type type) {
-  // Does token type represent relation operations?
-  switch (type) {
-    case LSS:
-    case LEQ:
-    case GTR:
-    case GEQ:
-    case EQL:
-    case NEQ:
-      return true;
-    default:
-      return false;
-  }
+    // Does token type represent relation operations?
+    switch (type) {
+        case LSS:
+        case LEQ:
+        case GTR:
+        case GEQ:
+        case EQL:
+        case NEQ:
+            return true;
+        default:
+            return false;
+    }
 }
 
 bool is_addop(token_type type) {
-  // Does token type represent plus/minus opperations?
-  switch (type) {
-    case ADD:
-    case SUB:
-      return true;
-    default:
-      return false;
-  }
+    // Does token type represent plus/minus opperations?
+    switch (type) {
+        case ADD:
+        case SUB:
+            return true;
+        default:
+            return false;
+    }
 }
 
 bool is_mulop(token_type type) {
-  // Does token type represent multiply/divide operations?
-  switch (type) {
-    case MUL:
-    case DIV:
-      return true;
-    default:
-      return false;
-  }
+    // Does token type represent multiply/divide operations?
+    switch (type) {
+        case MUL:
+        case DIV:
+            return true;
+        default:
+            return false;
+    }
 }
 
 void parser_relop() {
-  debug_entry();
-  if (is_relop(lookahead.type)) {
-    // we can call 'match' like that because of the check in the if 
-    parser_match(lookahead.type);
-  } else {
-    // operator not found, syntax error
-    throw_syntax_error(lookahead.type, line);
-  }
+    debug_entry();
+    if (is_relop(lookahead.type)) {
+        // we can call 'match' like that because of the check in the if 
+        parser_match(lookahead.type);
+    } else {
+        // operator not found, syntax error
+        throw_syntax_error(lookahead.type, line);
+    }
 }
 
 void parser_addop() {
@@ -585,92 +585,92 @@ void parser_addop() {
 }
 
 void parser_mulop() {
-  debug_entry();
-  if (is_mulop(lookahead.type)) {
-    // we can call 'match' like that because of the check in the if 
-    parser_match(lookahead.type);
-  } else {
-    // operator not found, syntax error
-    throw_syntax_error(lookahead.type, line);
-  }
+    debug_entry();
+    if (is_mulop(lookahead.type)) {
+        // we can call 'match' like that because of the check in the if 
+        parser_match(lookahead.type);
+    } else {
+        // operator not found, syntax error
+        throw_syntax_error(lookahead.type, line);
+    }
 }
 
 void parser_rel() {
-  debug_entry();
-  parser_add();
-  parser_rel_n();
+    debug_entry();
+    parser_add();
+    parser_rel_n();
 }
 
 void parser_rel_n() {
-  debug_entry();
-  // if token type is not relation operator, apply eps-rule
-  if (is_relop(lookahead.type)) {
-      // expand the relation operator
-      parser_relop();
-      parser_add();
-      parser_rel_n();
-  }
-  // apply eps-rule
+    debug_entry();
+    // if token type is not relation operator, apply eps-rule
+    if (is_relop(lookahead.type)) {
+        // expand the relation operator
+        parser_relop();
+        parser_add();
+        parser_rel_n();
+    }
+    // apply eps-rule
 }
 
 void parser_add() {
-  debug_entry();
-  parser_term();
-  parser_add_n();
+    debug_entry();
+    parser_term();
+    parser_add_n();
 }
 
 void parser_add_n() {
-  debug_entry();
-  // if token type is not add/sub perator, apply eps-rule
-  if (is_addop(lookahead.type)) {
-    parser_addop();
-    parser_term();
-    parser_add_n();
-  }
-  // apply eps-rule
+    debug_entry();
+    // if token type is not add/sub perator, apply eps-rule
+    if (is_addop(lookahead.type)) {
+        parser_addop();
+        parser_term();
+        parser_add_n();
+    }
+    // apply eps-rule
 }
 
 void parser_term() {
-  debug_entry();
-  parser_factor();
-  parser_term_n();
+    debug_entry();
+    parser_factor();
+    parser_term_n();
 }
 
 void parser_term_n() {
-  debug_entry();
-  // if token type is not mul/div operator, apply eps-rule
-  if (is_mulop(lookahead.type)) {
-    parser_mulop();
-    parser_factor();
-    parser_term_n();
-  }
-  // apply eps-rule
+    debug_entry();
+    // if token type is not mul/div operator, apply eps-rule
+    if (is_mulop(lookahead.type)) {
+        parser_mulop();
+        parser_factor();
+        parser_term_n();
+    }
+    // apply eps-rule
 }
 
 void parser_factor() {
-  debug_entry();
-  token_type t = lookahead.type;
+    debug_entry();
+    token_type t = lookahead.type;
 
-  if (t == LPAREN) {
-    parser_match(LPAREN);
-    parser_expr();
-    parser_match(RPAREN);
-  } else if (token_is_lit(t)) {
-    // can only match INT, FLOAT64, STRING due to is_lit()
-    parser_match(t);
-  } else if (t == IDENT) {
-    parser_match(IDENT);
-    parser_funexp();
-  } else {
-    throw_syntax_error(lookahead.type, line);
-  }
+    if (t == LPAREN) {
+        parser_match(LPAREN);
+        parser_expr();
+        parser_match(RPAREN);
+    } else if (token_is_lit(t)) {
+        // can only match INT, FLOAT64, STRING due to is_lit()
+        parser_match(t);
+    } else if (t == IDENT) {
+        parser_match(IDENT);
+        parser_funexp();
+    } else {
+        throw_syntax_error(lookahead.type, line);
+    }
 }
 
 void parser_funexp() {
-  debug_entry();
-  // if lookahead is '(', apply eps-rule
-  if (lookahead.type == LPAREN) {
-    parser_c_params();
-  }
-  // apply eps-rule
+    debug_entry();
+    // if lookahead is '(', apply eps-rule
+    if (lookahead.type == LPAREN) {
+        parser_c_params();
+    }
+    // apply eps-rule
 }

--- a/src/parser.h
+++ b/src/parser.h
@@ -1,9 +1,9 @@
 /**
  * @file parser.h
- * @author Marek Filip (xfilip46, Wecros), FIT BUT 
- * @date 10/11/2020
+ * @author Marek Filip <xfilip46>
  * @brief Header file for the parser.c
- * @details Parser is the heart of the compiler and its most difficult part.
+ * @details Implementace překladače imperativního jazyka IFJ20.
+ * @date 10/11/2020
  */
 
 #ifndef __PARSER_H__

--- a/src/scanner-private.c
+++ b/src/scanner-private.c
@@ -1,7 +1,10 @@
-/* scanner-private.c
- * Ondřej Míchal <xmicha80>
- * Vojtěch Bůbela <xbubel08>
- * 03/10/2020
+/**
+ * @file scanner-private.c
+ * @author Ondřej Míchal <xmicha80>
+ * @author Vojtěch Bůbela <xbubel08>
+ * @brief File with private scanner functions.
+ * @details Implementace překladače imperativního jazyka IFJ20.
+ * @date 03/10/2020
  */
 
 #include <ctype.h>
@@ -25,49 +28,51 @@
  * @param s an instance of scanner
  */
 void scanner_skip_whitespace_comments(scanner_t *s, bool *eol_encountered, int *line) {
-  // debug_entry();
-  comment_state state = CLEAN;
-  char prev_char;
+      // debug_entry();
+      comment_state state = CLEAN;
+      char prev_char;
 
-  do {
-    prev_char = s->character;
-    s->character = fgetc(s->file);
-    s->position++;
+      do {
+        prev_char = s->character;
+        s->character = fgetc(s->file);
+        s->position++;
 
-    if (state == BLOCK_EXITED)
-      state = CLEAN;
+        if (state == BLOCK_EXITED)
+              state = CLEAN;
 
-    switch (s->character) {
-      case '\n':
-        *eol_encountered = true;
-        (*line)++;
+        switch (s->character) {
+              case '\n':
+                *eol_encountered = true;
+                (*line)++;
 
-        if (state == INLINE_COMMENT)
-          state = CLEAN;
-        break;
-      case '/':
-        if (state == CLEAN)
-          state = COMMENT_CHANGE;
-        else if (state == BLOCK_COMMENT_LEAVING)
-          state = BLOCK_EXITED;
-        else if (state == COMMENT_CHANGE)
-          state = INLINE_COMMENT;
-        break;
-      case '*':
-        if (state == COMMENT_CHANGE)
-          state = BLOCK_COMMENT;
-        else if (state == BLOCK_COMMENT)
-          state = BLOCK_COMMENT_LEAVING;
-        break;
-      default:
-        if (state == COMMENT_CHANGE) {
-          ungetc(s->character, s->file);
-          s->character = prev_char;
-          state = CLEAN;
+                if (state == INLINE_COMMENT)
+                      state = CLEAN;
+                break;
+              case '/':
+                if (state == CLEAN) {
+                      state = COMMENT_CHANGE;
+                } else if (state == BLOCK_COMMENT_LEAVING) {
+                      state = BLOCK_EXITED;
+                } else if (state == COMMENT_CHANGE) {
+                      state = INLINE_COMMENT;
+                }
+                break;
+              case '*':
+                if (state == COMMENT_CHANGE) {
+                      state = BLOCK_COMMENT;
+                } else if (state == BLOCK_COMMENT) {
+                     state = BLOCK_COMMENT_LEAVING;
+                }
+                break;
+              default:
+                if (state == COMMENT_CHANGE) {
+                      ungetc(s->character, s->file);
+                      s->character = prev_char;
+                      state = CLEAN;
+                }
+                break;
         }
-        break;
-    }
-  } while(isspace(s->character) || state != CLEAN);
+      } while(isspace(s->character) || state != CLEAN);
 
   ungetc(s->character, s->file);
   s->position--;
@@ -86,20 +91,20 @@ void scanner_skip_whitespace_comments(scanner_t *s, bool *eol_encountered, int *
  * @retval 2 is sign to stop scanner and return token
  */
 int scan_string_lit(scanner_t *s) {
-  debug_entry();
-  if (s->character == '"') {
-    s->state = STOP;
-    return 2;
-  } else if ((s->character >= 32 && s->character <= 33) ||
-             (s->character >= 35 && s->character <= 91) ||
-             (s->character >= 93 && s->character <= 126)) {
-               return 0;
-  } else if (s->character == 92) {
-    s->state = q4;
-    return 0;
-  }
+    debug_entry();
+    if (s->character == '"') {
+        s->state = STOP;
+        return 2;
+    } else if ((s->character >= 32 && s->character <= 33) ||
+               (s->character >= 35 && s->character <= 91) ||
+               (s->character >= 93 && s->character <= 126)) {
+                    return 0;
+    } else if (s->character == 92) {
+        s->state = q4;
+        return 0;
+    }
 
-  return 1;
+    return 1;
 }
  
 /**
@@ -113,36 +118,34 @@ int scan_string_lit(scanner_t *s) {
  * @retval 1 on error
  */
 int scan_num_lit(scanner_t *s, token_t *t) {
-  debug_entry();
-  switch (s->character) {
+    debug_entry();
+    switch (s->character) {
 
-  case '0' ... '9':
+        case '0' ... '9':
+            return 0;
+            break;
 
-    return 0;
-    break;
+        case '.':
+            t->type = FLOAT64_LIT;
+            s->state = q7;
+            return 0;
+            break;
 
-  case '.':
-    t->type = FLOAT64_LIT;
-    s->state = q7;
-    return 0;
-    break;
+        case 'e':
+            t->type = FLOAT64_LIT;
+            s->state = q8;
+            return 0;
+            break;
 
-  case 'e':
-    t->type = FLOAT64_LIT;
-    s->state = q8;
-    return 0;
-    break;
+        case 'E':
+            t->type = FLOAT64_LIT;
+            s->state = q8;
+            return 0;
+            break;
 
-  case 'E':
-    t->type = FLOAT64_LIT;
-    s->state = q8;
-    return 0;
-    break;
-
-  
-  default:
-    break;
-  }
+        default:
+            break;
+    }
 
   return 1;
 }
@@ -160,160 +163,158 @@ int scan_num_lit(scanner_t *s, token_t *t) {
  */
 
 int innit_scan(scanner_t *s, token_t *t) {
-  debug_entry();
-  char peek;
+    debug_entry();
+    char peek;
   
-  switch(s->character) {
+    switch(s->character) {
         case ',':
-          t->type = COMMA;
-          s->state = STOP;
-          break;
+            t->type = COMMA;
+            s->state = STOP;
+            break;
 
         case ';':
-          t->type = SEMICOLON;
-          s->state = STOP;
-          break;
+            t->type = SEMICOLON;
+            s->state = STOP;
+            break;
 
         case '(':
-          t->type = LPAREN;
-          s->state = STOP;
-          break;
+            t->type = LPAREN;
+            s->state = STOP;
+             break;
 
         case ')':
-          t->type = RPAREN;
-          s->state = STOP;
-          break;
+            t->type = RPAREN;
+            s->state = STOP;
+            break;
 
         case '{':
-          t->type = LBRACE;
-          s->state = STOP;
-          break;
+            t->type = LBRACE;
+            s->state = STOP;
+            break;
 
         case '}':
-          t->type = RBRACE;
-          s->state = STOP;
-          break;
-       
+            t->type = RBRACE;
+            s->state = STOP;
+            break;
+
         case '+':
-          t->type = ADD;
-          s->state = STOP;
-          break;
+            t->type = ADD;
+            s->state = STOP;
+            break;
 
         case '-':
-          t->type = SUB;
-          s->state = STOP;
-          break;
+            t->type = SUB;
+            s->state = STOP;
+            break;
 
         case '/':
-          t->type = DIV;
-          s->state = STOP;
-          break;
+            t->type = DIV;
+            s->state = STOP;
+            break;
 
         case '*':
-          t->type = MUL;
-          s->state = STOP;
-          break;
+            t->type = MUL;
+            s->state = STOP;
+            break;
 
         case '<':
-          t->type = LSS;
-          s->state = STOP;
+            t->type = LSS;
+            s->state = STOP;
 
-          peek = fgetc(s->file);
+            peek = fgetc(s->file);
 
-          if (peek == '=') {
-            s->character = peek;
-            t->type = LEQ;
-          } else
-            ungetc(peek, s->file);
-
-          break;
+            if (peek == '=') {
+                s->character = peek;
+                t->type = LEQ;
+            } else {
+                ungetc(peek, s->file);
+            }
+            break;
 
         case '>':
-          t->type = GTR;
-          s->state = STOP;
+            t->type = GTR;
+            s->state = STOP;
 
-          peek = fgetc(s->file);
+            peek = fgetc(s->file);
 
-          if (peek == '=') {
-            s->character = peek;
-            t->type = GEQ;
-          } else
-            ungetc(peek, s->file);
-
-          break;
+            if (peek == '=') {
+                s->character = peek;
+                t->type = GEQ;
+            } else {
+                ungetc(peek, s->file);
+            }
+            break;
 
         case '=':
-          t->type = ASSIGN;
-          s->state = STOP;
+            t->type = ASSIGN;
+            s->state = STOP;
 
-          peek = fgetc(s->file);
+            peek = fgetc(s->file);
 
-          if (peek == '=') {
-            s->character = peek;
-            t->type = EQL;
-          } else
-            ungetc(peek, s->file);
-
-          break;
+            if (peek == '=') {
+                s->character = peek;
+                t->type = EQL;
+            } else {
+                ungetc(peek, s->file);
+            }
+            break;
 
         case ':':
-          peek = fgetc(s->file);
+            peek = fgetc(s->file);
 
-          if (peek == '=') {
-            s->character = peek;
-            t->type = DEFINE;
-            s->state = STOP;
-          } else {
-            ungetc(peek, s->file);
-            s->state = LEX_ERROR;
-          }
-
-          break;
+            if (peek == '=') {
+                s->character = peek;
+                t->type = DEFINE;
+                s->state = STOP;
+            } else {
+                ungetc(peek, s->file);
+                s->state = LEX_ERROR;
+            }
+            break;
 
         case '!':
-          peek = fgetc(s->file);
+            peek = fgetc(s->file);
 
-          if (peek == '=') {
-            s->character = peek;
-            t->type = NEQ;
-            s->state = STOP;
-          } else {
-            ungetc(peek, s->file);
-            s->state = LEX_ERROR;
-          }
-
-          break;
+            if (peek == '=') {
+                s->character = peek;
+                t->type = NEQ;
+                s->state = STOP;
+            } else {
+                ungetc(peek, s->file);
+                s->state = LEX_ERROR;
+            }
+            break;
 
         case '_':
         case 'a' ... 'z':
-          t->type = IDENT;
-          s->state = f10;
-          break;
+            t->type = IDENT;
+            s->state = f10;
+            break;
 
         case '1': case '2': case '3': case '4': case '5': 
         case '6': case '7': case '8': case '9':
-          t->type = INT_LIT;
-          s->state = f14;
-          break;
+            t->type = INT_LIT;
+            s->state = f14;
+            break;
 
         case '0':
-          t->type = INT_LIT;
-          s->state = f15;
-          break;
+            t->type = INT_LIT;
+            s->state = f15;
+            break;
 
         case '"':
-          t->type = STRING_LIT;
-          s->state = q3;
-          break;
+            t->type = STRING_LIT;
+            s->state = q3;
+            break;
 
         default:
-          s->state = LEX_ERROR;
-          break;
-      }
+            s->state = LEX_ERROR;
+            break;
+        }
 
-      if (s->state == LEX_ERROR)
+    if (s->state == LEX_ERROR)
         return 1;
 
-      return 0;
+    return 0;
 }
 

--- a/src/scanner-private.h
+++ b/src/scanner-private.h
@@ -1,7 +1,9 @@
 /**
  * @file scanner-private.h
  * @author Ondřej Míchal <xmicha80>
- * @author Vojtech Fiala <xfiala61>
+ * @author Vojtěch Fiala <xfiala61>
+ * @brief Header file for scanner-private.c that defines states of the DFA
+ * @details Implementace překladače imperativního jazyka IFJ20.
  * @date 03/10/2020
  */
 
@@ -11,55 +13,55 @@
 
 typedef enum scanner_state
 {
-  INIT, //rename to 'Start'?
-  f3,   //enter this state after '<' was read from INIT state
-  f5,   //enter this state after '>' was read from INIT state
-  f7,   //enter this state after '=' was read from INIT state
-  f10,  //enter this state after [_a-zA-Z] was read from INIT state
-  f14,  //enter this state after [1-9] was read from INIT state
-  f15,  //enter this state after '0' was read from INIT state
+    INIT, //rename to 'Start'?
+    f3,   //enter this state after '<' was read from INIT state
+    f5,   //enter this state after '>' was read from INIT state
+    f7,   //enter this state after '=' was read from INIT state
+    f10,  //enter this state after [_a-zA-Z] was read from INIT state
+    f14,  //enter this state after [1-9] was read from INIT state
+    f15,  //enter this state after '0' was read from INIT state
 
-  q1,   //enter this state after '!' was read from INIT state
-  q2,   //enter this state after ':' was read from INIT state
+    q1,   //enter this state after '!' was read from INIT state
+    q2,   //enter this state after ':' was read from INIT state
 
-  q3,   //enter this state after '"' was read from INIT state
-        //or [\x20-x5Bx\5D-x\7F] was read from q3 state
-        //or 'n', 't', '\' or '"' was read from q4 state
-        //or [0-9a-fA-F] was read from q6 state
+    q3,   //enter this state after '"' was read from INIT state
+            //or [\x20-x5Bx\5D-x\7F] was read from q3 state
+            //or 'n', 't', '\' or '"' was read from q4 state
+            //or [0-9a-fA-F] was read from q6 state
 
-  q4,   //enter this state after '\' was read from q3 state
-  q5,   //enter this state after 'x' was read from q4 state
-  q6,   //enter this state after [0-9a-fA-F] was read from q5 state
-  q7,   //TODO
-  q8,   //TODO
-  q9,   //TODO
-  f12,  //TODO
-  f13,  //TODO
-  f16,  //TODO
-  f17,  //TODO
+    q4,   //enter this state after '\' was read from q3 state
+    q5,   //enter this state after 'x' was read from q4 state
+    q6,   //enter this state after [0-9a-fA-F] was read from q5 state
+    q7,   //TODO
+    q8,   //TODO
+    q9,   //TODO
+    f12,  //TODO
+    f13,  //TODO
+    f16,  //TODO
+    f17,  //TODO
 
-  STOP,   //finite state machine is in final step
-  LEX_ERROR,
+    STOP,   //finite state machine is in final step
+    LEX_ERROR,
 } scanner_state;
 
 struct scanner
 {
-  FILE *file; /**< the scanned file*/
-  int position; /**< reading position*/
+    FILE *file; /**< the scanned file*/
+    int position; /**< reading position*/
 
-  scanner_state state; /**< scanner's state*/
+    scanner_state state; /**< scanner's state*/
 
-  char character; /**< currently assessed character*/
+    char character; /**< currently assessed character*/
 };
 
 typedef enum comment_state
 {
-  CLEAN, /**< the reader is not in a comment (or may not become) */
-  COMMENT_CHANGE, /**< the next character could open/close a comment */
-  INLINE_COMMENT, /**< the next character is a part of an inline comment */
-  BLOCK_COMMENT, /**< the next character is a part of a block comment */
-  BLOCK_COMMENT_LEAVING, /**< the next character may end a block comment */
-  BLOCK_EXITED /**< current character closed a block comment */
+      CLEAN, /**< the reader is not in a comment (or may not become) */
+      COMMENT_CHANGE, /**< the next character could open/close a comment */
+      INLINE_COMMENT, /**< the next character is a part of an inline comment */
+      BLOCK_COMMENT, /**< the next character is a part of a block comment */
+      BLOCK_COMMENT_LEAVING, /**< the next character may end a block comment */
+      BLOCK_EXITED /**< current character closed a block comment */
 } comment_state;
 
 void scanner_skip_whitespace_comments(scanner_t *s, bool *eol_encountered, int *line);

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1,9 +1,11 @@
-/*
- * scanner.c
- * Ondřej Míchal <xmicha80>
- * Vojtěch Bůbela <xbubel08>
- * Vojtěch Fiala <xfiala61>
- * 08/11/2020
+/**
+ * @file scanner.c
+ * @author Ondřej Míchal <xmicha80>
+ * @author Vojtěch Bůbela <xbubel08>
+ * @author Vojtěch Fiala <xfiala61>
+ * @brief Scanner DFA
+ * @details Implementace překladače imperativního jazyka IFJ20.
+ * @date 08/11/2020
  */
 
 #include <ctype.h>
@@ -26,16 +28,16 @@
  * @return an instance of scanner (or NULL on error)
  */
 scanner_t *scanner_new(FILE *f) {
-  debug_entry();
-  scanner_t *s = malloc(sizeof(struct scanner));
-  if (s == NULL)
-    return NULL;
+    debug_entry();
+    scanner_t *s = malloc(sizeof(struct scanner));
+    if (s == NULL)
+        return NULL;
 
-  s->file = f;
-  s->position = 0;
-  s->state = INIT;
+    s->file = f;
+    s->position = 0;
+    s->state = INIT;
 
-  return s;
+    return s;
 }
 
 /**
@@ -44,9 +46,9 @@ scanner_t *scanner_new(FILE *f) {
  * @param s an instance of scanner
  */
 void scanner_free(scanner_t *s) {
-  debug_entry();
-  if (s != NULL)
-    free(s);
+    debug_entry();
+    if (s != NULL)
+        free(s);
 }
 
 /**
@@ -68,242 +70,232 @@ void scanner_free(scanner_t *s) {
  * @retval EOF end of file
  */
 int scanner_scan(scanner_t *s, token_t *t, bool *eol_encountered, int *line) {
-  debug_entry();
-  string str;
+    debug_entry();
+    string str;
 
-  if (s == NULL)
-    return ERROR_INTERNAL;
+    if (s == NULL)
+        return ERROR_INTERNAL;
 
-  if (s->file == NULL)
-    return ERROR_INTERNAL;
+    if (s->file == NULL)
+        return ERROR_INTERNAL;
 
-  if (t == NULL)
-    return ERROR_INTERNAL;
+    if (t == NULL)
+        return ERROR_INTERNAL;
 
-  // Scan initialization
-  s->state = INIT;
-  token_init(t);
-  if (strInit(&str) == 1)
-    return ERROR_INTERNAL;
+    // Scan initialization
+    s->state = INIT;
+    token_init(t);
+    if (strInit(&str) == 1)
+        return ERROR_INTERNAL;
 
-  // Skip comments and whitespace characters
-  scanner_skip_whitespace_comments(s, eol_encountered, line);
+    // Skip comments and whitespace characters
+    scanner_skip_whitespace_comments(s, eol_encountered, line);
 
-  // Token State Machine
-  // TODO: Actually implement the state machine :)
-  do {
-    int return_val;
+    // Token State Machine
+    // TODO: Actually implement the state machine :)
+    do {
+        int return_val;
 
-    // Get the next character
-    s->character = fgetc(s->file);
+        // Get the next character
+        s->character = fgetc(s->file);
 
-    if (s->character == EOF) {
-      s->state = STOP;
-      t->type = EOF_T;
-    }
-
-    switch (s->state) {
-      /*
-      * initial scan solves all branches of DKA apart from
-      * numerical literal, decimal literal, identifier and
-      * string literal 
-      */
-
-      //-----beggining of initial scan------
-      case INIT:
-        innit_scan(s, t);
-        break;
-      //-----end of initial scan-----
-
-      /*
-      * this part of code is for numerical literal 
-      */
-
-      //-----beggining of numerical literal scan------
-      case f14:
-        if (scan_num_lit(s, t) == 1) {
-          ungetc(s->character, s->file);
-          s->state = STOP;
+        if (s->character == EOF) {
+            s->state = STOP;
+            t->type = EOF_T;
         }
 
-        break;
+        switch (s->state) {
+        /*
+        * initial scan solves all branches of DFA apart from
+        * numerical literal, decimal literal, identifier and
+        * string literal 
+        */
 
-       case f15:
-        if ((s->character == 'e') || (s->character == 'E')) {
-          t->type = FLOAT64_LIT;
-          s->state = q8;
-        } else if (s->character == '.') {   //0.X
-          t->type = FLOAT64_LIT;
-          s->state = q7;
-        } else {
-          ungetc(s->character, s->file);
-          t->type = INT_LIT;
-          s->state = STOP;
-        }
+            //-----beggining of initial scan------
+            case INIT:
+                innit_scan(s, t);
+                break;
+            //-----end of initial scan-----
 
-        break;
-      //-----end of numerical literal scan------
+            /*
+            * this part of code is for numerical literal 
+            */
 
-      /*
-      * this part of code is for deciaml literal 
-      */
+            //-----beggining of numerical literal scan------
+            case f14:
+                if (scan_num_lit(s, t) == 1) {
+                    ungetc(s->character, s->file);
+                    s->state = STOP;
+                }
+                break;
 
-      //-----beggining of decimal literal scan-----
-      case q7:
-        if (s->character >= 48 && s->character <= 57) {
-          s->state = f16;
-        } else {
-          ungetc(s->character, s->file);
-          s->state = LEX_ERROR;
-        }
-        break;
+            case f15:
+                if ((s->character == 'e') || (s->character == 'E')) {
+                    t->type = FLOAT64_LIT;
+                    s->state = q8;
+                } else if (s->character == '.') {   //0.X
+                    t->type = FLOAT64_LIT;
+                    s->state = q7;
+                } else {
+                    ungetc(s->character, s->file);
+                    t->type = INT_LIT;
+                    s->state = STOP;
+                }
+                break;
+            //-----end of numerical literal scan------
 
-      case q8:
-        if (s->character == '+' || s->character == '-') {
-          s->state = q9;
-        } else if (s->character >= 48 && s->character <= 57) {
-          s->state = f17;
-        } else {
-          s->state = LEX_ERROR;
-        }
+            /*
+            * this part of code is for decimal literal 
+            */
 
-        break;
+            //-----beggining of decimal literal scan-----
+            case q7:
+                if (s->character >= 48 && s->character <= 57) {
+                    s->state = f16;
+                } else {
+                    ungetc(s->character, s->file);
+                    s->state = LEX_ERROR;
+                }
+                break;
 
-      case q9:
-        if (s->character >= 48 && s->character <= 57) {
-          s->state = f17;
-        } else {
-          ungetc(s->character, s->file);   // is this necessary? 
-          s->state = LEX_ERROR;
-        }
+            case q8:
+                if (s->character == '+' || s->character == '-') {
+                    s->state = q9;
+                } else if (s->character >= 48 && s->character <= 57) {
+                    s->state = f17;
+                } else {
+                    s->state = LEX_ERROR;
+                }
+                break;
 
-        break;
+            case q9:
+                if (s->character >= 48 && s->character <= 57) {
+                    s->state = f17;
+                } else {
+                    ungetc(s->character, s->file);   // is this necessary? 
+                    s->state = LEX_ERROR;
+                }
+                break;
 
-      case f16:
-        if ((s->character == 'e') || (s->character == 'E')) {
-          s->state = q8;
-        } 
+            case f16:
+                if ((s->character == 'e') || (s->character == 'E')) {
+                    s->state = q8;
+                } 
         
-        else if (s->character >= 48 && s->character <= 57) {    
-          s->state = f16;       // If after X.Y we have another number, keep on looping
-        }
+                else if (s->character >= 48 && s->character <= 57) {    
+                    s->state = f16;       // If after X.Y we have another number, keep on looping
+                }
 
-        else {                  // Else we found another token, so return to its beginning and stop
-            s->state = STOP;
-            ungetc(s->character, s->file);
-        }
+                else {                  // Else we found another token, so return to its beginning and stop
+                    s->state = STOP;
+                    ungetc(s->character, s->file);
+                }
+                break;
 
-        break;
+            case f17:
+                if (!(s->character >= 48 && s->character <= 57)) {
+                    s->state = STOP;
+                    ungetc(s->character, s->file);
+                }
+                break;
+            //----end of decimal literal scan-----
 
-      case f17:
-        if (!(s->character >= 48 && s->character <= 57)) {
-          s->state = STOP;
-          ungetc(s->character, s->file);
-        }
+            /*
+            * this part of code is for string literal 
+            */
 
-        break;
-      //----end of decimal literal scan-----
+            //-----beggining of string literal scan-----
+            case q3:
+                return_val = scan_string_lit(s);
+                if (return_val == 1) {
+                    s->state = LEX_ERROR;
+                } else if (return_val == 2) {
+                    s->state = STOP;
+                    if ((strAddChar(&str, s->character)) == 1) {
+                        return ERROR_INTERNAL;
+                    }
+                }
+                break;
 
-      /*
-      * this part of code is for string literal 
-      */
+            case q4:
+                if (s->character == 'x') {
+                    s->state = q5;
+                } else if (s->character == 'n' ||
+                           s->character == 't' ||
+                           s->character == 92  ||
+                           s->character == '"') {
+                                s->state = q3;
+                } else {
+                    s->state = LEX_ERROR;
+                }
+                break;
 
-      //-----beggining of string literal scan-----
-      case q3:
-        return_val = scan_string_lit(s);
-        if (return_val == 1)
-          s->state = LEX_ERROR;
-        else if (return_val == 2) {
-            s->state = STOP;
+            case q5:
+                if (!(s->character >= 48 && s->character <= 57) ||
+                    !(s->character >= 65 && s->character <= 90) ||
+                    !(s->character >= 97 && s->character <= 122)) {
+                        s->state = LEX_ERROR;
+                } else {
+                    s->state = q6;
+                }      
+                break;
+
+            case q6:
+                if (!(s->character >= 48 && s->character <= 57) ||
+                    !(s->character >= 65 && s->character <= 90) ||
+                    !(s->character >= 97 && s->character <= 122)) {
+                        s->state = LEX_ERROR;
+                } else {
+                    s->state = q3;
+                }   
+                break;
+            //----end of string literal scan-----
+
+            /*
+            * this part of code is for identifiers
+            */
+
+            //-----beggining of identifier scan-----
+            case f10:
+                if (isspace(s->character)) {
+                s->state = STOP;
+                ungetc(s->character, s->file);
+                break;
+               } else if ((s->character != '_') &&
+                        !(s->character >= 48 && s->character <= 57) &&
+                        !(s->character >= 65 && s->character <= 90) &&
+                        !(s->character >= 97 && s->character <= 122)) {
+                            s->state = STOP;
+                            ungetc(s->character, s->file);
+                }
+                break;
+            //-----end of identifier scan-----
+
+            case STOP:
+                break;
+
+            default:
+                s->state = LEX_ERROR;
+                t->type = INVALID;
+                break;
+            }
+
+        if (s->state != STOP && s->state != LEX_ERROR) {
             if ((strAddChar(&str, s->character)) == 1) {
                 return ERROR_INTERNAL;
             }
         }
-        break;
-
-      case q4:
-          if (s->character == 'x') {
-            s->state = q5;
-            } else if (s->character == 'n' ||
-                       s->character == 't' ||
-                       s->character == 92  ||
-                       s->character == '"') {
-                         s->state = q3;
-            } else {
-                s->state = LEX_ERROR;
-            }
-
-            break;
-
-      case q5:
-        if (!(s->character >= 48 && s->character <= 57) ||
-            !(s->character >= 65 && s->character <= 90) ||
-            !(s->character >= 97 && s->character <= 122)) {
-              s->state = LEX_ERROR;
-            } else {
-              s->state = q6;
-            }      
-
-        break;
-
-      case q6:
-        if (!(s->character >= 48 && s->character <= 57) ||
-            !(s->character >= 65 && s->character <= 90) ||
-            !(s->character >= 97 && s->character <= 122)) {
-              s->state = LEX_ERROR;
-            } else {
-              s->state = q3;
-            }   
-
-        break;
-      //----end of string literal scan-----
-
-      /*
-      * this part of code is for identifiers
-      */
-
-      //-----beggining of identifier scan-----
-      case f10:
-        if (isspace(s->character)) {
-          s->state = STOP;
-          ungetc(s->character, s->file);
-          break;
-        } else if ((s->character != '_') &&
-                  !(s->character >= 48 && s->character <= 57) &&
-                  !(s->character >= 65 && s->character <= 90) &&
-                  !(s->character >= 97 && s->character <= 122)) {
-
-               s->state = STOP;
-               ungetc(s->character, s->file);
-             }
-        break;
-      //-----end of identifier scan-----
-
-      case STOP:
-        break;
-
-      default:
-        s->state = LEX_ERROR;
-        t->type = INVALID;
-        break;
-    }
-
-    if (s->state != STOP && s->state != LEX_ERROR) {
-      if ((strAddChar(&str, s->character)) == 1) {
-        return ERROR_INTERNAL;
-      }
-    }
-  } while (s->state != STOP && s->state != LEX_ERROR);
+    } while (s->state != STOP && s->state != LEX_ERROR);
  
-  token_set_attribute(t, str);
-  strFree(&str);
+    token_set_attribute(t, str);
+    strFree(&str);
 
-  if (s->character == EOF)
-    return EOF;
+    if (s->character == EOF)
+        return EOF;
 
-  if (s->state == LEX_ERROR)
-    return ERROR_LEXICAL;
+    if (s->state == LEX_ERROR)
+        return ERROR_LEXICAL;
 
-  return 0;
+    return 0;
 }
  

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -1,7 +1,9 @@
-/**
+/** 
  * @file scanner.h
  * @author Ondřej Míchal <xmicha80>
  * @author Vojtěch Bůbela <xbubel08>
+ * @brief File with scanner function declarations
+ * @details Implementace překladače imperativního jazyka IFJ20.
  * @date 03/10/2020
  */
 

--- a/src/token.c
+++ b/src/token.c
@@ -1,8 +1,11 @@
-/*
- * token.c
- * Vojtěch Bůbela <xbubel08>
- * Vojtech Fiala <xfiala61>
- * 09/11/2020
+/**
+ * @file token.c
+ * @author Vojtěch Bůbela <xbubel08>
+ * @author Vojtěch Fiala <xfiala61>
+ * @author Ondřej Míchal <xmicha80>
+ * @brief File containing token-related functions
+ * @details Implementace překladače imperativního jazyka IFJ20.
+ * @date 09/11/2020
  */
 
 #include "token.h"
@@ -41,7 +44,7 @@ void token_set_attribute(token_t *t, string str) {
             strCopyString(&t->attribute.str_val, &str);
             // Set token type matching the keyword
             if (ident_is_keyword(str) == 0)
-              t->type = get_keyword_type(str);
+                t->type = get_keyword_type(str);
             break;
         default: 
             return;
@@ -58,9 +61,8 @@ void token_init(token_t *t) {
 }
 
 void token_free(token_t *t) {
-  if (t != NULL) {
-    free(t);
-  }
+    if (t != NULL)
+        free(t);
 }
 
 /**
@@ -75,91 +77,92 @@ void token_set_type(token_t *t, token_type type) {
 }
 
 int ident_is_keyword(string str) {
-  symtable_iterator_t it = symtable_find(keywords_symtable, str.str);
-  if (symtable_iterator_valid(it))
-    return 0;
-  else
-    return 1;
+    symtable_iterator_t it = symtable_find(keywords_symtable, str.str);
+    if (symtable_iterator_valid(it)) {
+        return 0;
+    } else {
+        return 1;
+    }
 }
 
 token_type get_keyword_type(string str) {
-  symtable_iterator_t it = symtable_find(keywords_symtable, str.str);
-  symtable_value_t val = symtable_iterator_get_value(it);
-  return val.type;
+    symtable_iterator_t it = symtable_find(keywords_symtable, str.str);
+    symtable_value_t val = symtable_iterator_get_value(it);
+    return val.type;
 }
 
 const char* token_get_type_string(token_type type) {
-  switch (type) {
-    case INVALID: return "INVALID";
-    case EOL: return "EOL";
-    case EOF_T: return "EOF_T";
-    case IDENT: return "IDENT";
+    switch (type) {
+        case INVALID: return "INVALID";
+        case EOL: return "EOL";
+        case EOF_T: return "EOF_T";
+        case IDENT: return "IDENT";
 
-    // Literals
-    case INT_LIT: return "INT_LIT";
-    case FLOAT64_LIT: return "FLOAT64_LIT";
-    case STRING_LIT: return "STRING_LIT";
+        // Literals
+        case INT_LIT: return "INT_LIT";
+        case FLOAT64_LIT: return "FLOAT64_LIT";
+        case STRING_LIT: return "STRING_LIT";
 
-    // Data types
-    case INT: return "INT";
-    case FLOAT64: return "FLOAT64";
-    case STRING: return "STRING";
+        // Data types
+        case INT: return "INT";
+        case FLOAT64: return "FLOAT64";
+        case STRING: return "STRING";
 
-    // Control
-    case IF: return "IF";
-    case ELSE: return "ELSE";
-    case FOR: return "FOR";
+        // Control
+        case IF: return "IF";
+        case ELSE: return "ELSE";
+        case FOR: return "FOR";
 
-    // Functions
-    case FUNC: return "FUNC";
-    case RETURN: return "RETURN";
+        // Functions
+        case FUNC: return "FUNC";
+        case RETURN: return "RETURN";
 
-    // Package declaration
-    case PACKAGE: return "PACKAGE";
+        // Package declaration
+        case PACKAGE: return "PACKAGE";
 
-    // Assignment
-    case DEFINE: return "DEFINE";
-    case ASSIGN: return "ASSIGN";
+        // Assignment
+        case DEFINE: return "DEFINE";
+        case ASSIGN: return "ASSIGN";
 
-    // Operators
-    case ADD: return "ADD";
-    case SUB: return "SUB";
-    case MUL: return "MUL";
-    case DIV: return "DIV";
+        // Operators
+        case ADD: return "ADD";
+        case SUB: return "SUB";
+        case MUL: return "MUL";
+        case DIV: return "DIV";
 
-    // Comparators
-    case AND: return "AND";
-    case OR: return "OR";
-    case EQL: return "EQL";
-    case NEQ: return "NEQ";
-    case LSS: return "LSS";
-    case LEQ: return "LEQ";
-    case GTR: return "GTR";
-    case GEQ: return "GEQ";
+        // Comparators
+        case AND: return "AND";
+        case OR: return "OR";
+        case EQL: return "EQL";
+        case NEQ: return "NEQ";
+        case LSS: return "LSS";
+        case LEQ: return "LEQ";
+        case GTR: return "GTR";
+        case GEQ: return "GEQ";
 
-    //  Other
-    case LPAREN: return "LPAREN";
-    case LBRACE: return "LBRACE";
-    case RPAREN: return "RPAREN";
-    case RBRACE: return "RBRACE";
-    case COMMA: return "COMMA";
-    case SEMICOLON: return "SEMICOLON";
-    default:
-      break;
-  }
-  return NULL;
+        //  Other
+        case LPAREN: return "LPAREN";
+        case LBRACE: return "LBRACE";
+        case RPAREN: return "RPAREN";
+        case RBRACE: return "RBRACE";
+        case COMMA: return "COMMA";
+        case SEMICOLON: return "SEMICOLON";
+        default:
+            break;
+    }
+    return NULL;
 }
 
 bool token_is_lit(token_type type) {
-  debug_entry();
-  // is token type a literal?
-  switch (type) {
-    case INT_LIT:
-    case FLOAT64_LIT:
-    case STRING_LIT:
-      return true;
-    default:
-      return false;
-  }
+    debug_entry();
+    // is token type a literal?
+    switch (type) {
+        case INT_LIT:
+        case FLOAT64_LIT:
+        case STRING_LIT:
+            return true;
+        default:
+            return false;
+    }
 }
 

--- a/src/token.h
+++ b/src/token.h
@@ -4,6 +4,8 @@
  * @author Marek Filip <xfilip46>
  * @author Vojtěch Fiala <xfiala61>
  * @author Vojtěch Bůbela <xbubel08>
+ * @brief File with token type and functions definitons
+ * @details Implementace překladače imperativního jazyka IFJ20.
  * @date 09/11/2020
  */
 
@@ -15,74 +17,74 @@
 #include "str.h"
 
 typedef enum token_type {
-  // General
-  INVALID,  /**< Invalid token (Lexical error) */
-  EOL, 		/**< End of line */
-  EOF_T, 	/**< End of file */
-  IDENT,    /**< temp_value */
+    // General
+    INVALID,  // Invalid token (Lexical error)
+    EOL, 		// End of line
+    EOF_T, 	// End of file
+    IDENT,    // temp_value
 
-  // Literals
-  INT_LIT, 	   /**< 42 */
-  FLOAT64_LIT, /**< 42.42 */
-  STRING_LIT,  /**< "fourtytwo" */
+    // Literals
+    INT_LIT, 	   // 42
+    FLOAT64_LIT, // 42.42
+    STRING_LIT,  // "fourtytwo"
 
-  // Data types
-  INT, 		   /**< int */
-  FLOAT64, 	   /**< float64 */
-  STRING,  	   /**< string */
+    // Data types
+    INT, 		   // int
+    FLOAT64, 	   // float64
+    STRING,  	   // string
 
-  // Control
-  IF,   /**< if */
-  ELSE, /**< else */
-  FOR,  /**< for */
+    // Control
+    IF,   // if
+    ELSE, // else
+    FOR,  // for
 
-  // Functions
-  FUNC,   /**< func */
-  RETURN, /**<return */
+    // Functions
+    FUNC,   // func
+    RETURN, // return
 
-  // Package declaration
-  PACKAGE, /**< package */
+    // Package declaration
+    PACKAGE, // package
 
-  // Assignment
-  DEFINE, /**< := */
-  ASSIGN, /**< = */
+    // Assignment
+    DEFINE, // :=
+    ASSIGN, // =
 
-  // Operators
-  ADD, /**< "+" */
-  SUB, /**< "-" */
-  MUL, /**< "*" */
-  DIV, /**< "/" */
+    // Operators
+    ADD, // +
+    SUB, // -
+    MUL, // *
+    DIV, // /
 
-  // Comparators
-  AND, /**< && */
-  OR,  /**< || */
-  EQL, /**< == */
-  NEQ, /**< != */
-  LSS, /**< < */
-  LEQ, /**< <= */
-  GTR, /**< \> */
-  GEQ, /**< >= */
+    // Comparators
+    AND, // &&
+    OR,  // ||
+    EQL, // ==
+    NEQ, // !=
+    LSS, // <
+    LEQ, // <=
+    GTR, // >
+    GEQ, // >=
 
-  //  Other
-  LPAREN, 	/**< ( */
-  LBRACE, 	/**< { */
-  RPAREN, 	/**< ) */
-  RBRACE, 	/**< } */
-  COMMA,  	/**< , */
-  SEMICOLON /**< ; */
+    //  Other
+    LPAREN, 	// (
+    LBRACE, 	// {
+    RPAREN, 	// )
+    RBRACE, 	// }
+    COMMA,  	// ,
+    SEMICOLON // ;
 } token_type;
 
 /**
  * @brief Token holds information about a scanned lexem
  */
 typedef struct token {
-  token_type type; /**< Type of the token */
-  union Attribute {
-	int64_t int_val;
-	double float_val;
-	string str_val;
-	char *sym_key;	
-  } attribute; /**< Token's attribute (e.g., symtable key, value of int,..). */
+    token_type type; /**< Type of the token */
+    union Attribute {
+        int64_t int_val;
+        double float_val;
+        string str_val;
+        char *sym_key;	
+    } attribute; /**< Token's attribute (e.g., symtable key, value of int,..). */
 } token_t;
 
 void token_init(token_t *t);


### PR DESCRIPTION
The doxygen headers have been set as we agreed, the coding style has been changed.
I only changed the imporant files which will be part of the final version.

_What has been changed --_

```
Instead of 2 spaces, we now use 4 spaces.

An if/else syntax has been united (mostly).

All files now have the same syntax of doxygen header.
```

I did not change ``str.h and str.c`` files because I wasn't sure if I should change something that isn't ours.

I also didn't change @HarryMichal 's symtable because it has only been slightly edited for our purposes (similar to ``str.c/str.h``). The original is his and therefore I believe that if he likes it as it is, there is no need to change it (Unless you think otherwise - if that's the case, let me know).


**Let's make our code great again!**