### PR TITLE
ast: Add types for abstract syntactic tree

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -16,6 +16,7 @@ CFLAGS += -DNDEBUG
 endif
 
 public_sources = \
+	ast.c \
 	debug.c \
 	error.c \
 	global.c \
@@ -30,6 +31,7 @@ public_sources = \
 	token.c
 
 public_headers = \
+	ast.h \
 	debug.h \
 	error.h \
 	global.h \

--- a/src/ast.c
+++ b/src/ast.c
@@ -1,0 +1,116 @@
+/**
+ * @file ast.c
+ * @author Ondřej Míchal <xmicha80>
+ * @brief Abstract representations of syntactic entities
+ * @details Implementace překladače imperativního jazyka IFJ20.
+ * @date 26/11/2020
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include "ast.h"
+#include "debug.h"
+#include "str.h"
+#include "token.h"
+
+/*
+ * function_parameter_t
+ */
+
+func_parameter_t *func_parameter_new() {
+    debug_entry();
+
+    func_parameter_t *p = malloc(sizeof(struct function_parameter));
+    if (p == NULL)
+        return NULL;
+
+    strInit(&p->id);
+    p->next_param = NULL;
+    p->type = INVALID;
+
+    return p;
+}
+
+void func_parameter_free(func_parameter_t *p) {
+    debug_entry();
+
+    if (p == NULL)
+        return;
+
+    strFree(&p->id);
+    free(p);
+}
+
+/*
+ * function_return_t
+ */
+
+func_return_t *func_return_new() {
+    debug_entry();
+
+    func_return_t *r = malloc(sizeof(struct function_return));
+    if (r == NULL)
+        return NULL;
+
+    r->type = INVALID;
+    r->next_return = NULL;
+
+    return r;
+}
+
+void func_return_free(func_return_t *r) {
+    debug_entry();
+
+    if (r == NULL)
+        return;
+
+    free(r);
+}
+
+/*
+ * struct function
+ */
+
+void func_init(func_t *f) {
+    debug_entry();
+
+    if (f == NULL)
+        return;
+
+    strInit(&f->id);
+    f->num_of_parameters = 0;
+    f->num_of_returns = 0;
+    f->first_parameter = NULL;
+    f->first_return = NULL;
+}
+
+void func_free(func_t *f) {
+    debug_entry();
+
+    if (f == NULL)
+        return;
+
+    strFree(&f->id);
+    func_parameter_t *p_tmp = f->first_parameter;
+    while(f->first_parameter != NULL) {
+        p_tmp = p_tmp->next_param;
+        free(f->first_parameter);
+        f->first_parameter = p_tmp;
+    }
+    func_return_t *r_tmp = f->first_return;
+    while(f->first_return != NULL) {
+        r_tmp = r_tmp->next_return;
+        free(f->first_return);
+        f->first_return = r_tmp;
+    }
+}
+
+void func_set_id(func_t *f, char *id) {
+    debug_entry();
+
+    if (f == NULL)
+        return;
+
+    for (size_t i = 0; i < strlen(id); i++)
+        strAddChar(&f->id, id[i]);
+}

--- a/src/ast.h
+++ b/src/ast.h
@@ -1,0 +1,48 @@
+/**
+ * @file ast.c
+ * @author Ondřej Míchal <xmicha80>
+ * @brief Abstract representations of syntactic entities
+ * @details Implementace překladače imperativního jazyka IFJ20.
+ * @date 26/11/2020
+ */
+
+#include "str.h"
+#include "token.h"
+
+#ifndef __AST_H__
+#define __AST_H__
+
+typedef struct function_parameter {
+    string id;
+    token_type type;
+
+    struct function_parameter *next_param;
+} func_parameter_t;
+
+func_parameter_t *func_parameter_new();
+void func_parameter_free(func_parameter_t *p);
+
+typedef struct function_return {
+    token_type type;
+
+    struct function_return *next_return;
+} func_return_t;
+
+func_return_t *func_return_new();
+void func_return_free(func_return_t *r);
+
+typedef struct function {
+    string id;
+
+    int num_of_parameters;
+    func_parameter_t *first_parameter;
+
+    int num_of_returns;
+    func_return_t *first_return;
+} func_t;
+
+void func_init(func_t *f);
+void func_free(func_t *f);
+void func_set_id(func_t *f, char *id);
+
+#endif // __AST_H__

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -14,6 +14,7 @@ LDFLAGS = -lgtest -pthread
 
 tests_sources = \
 	tests.cpp \
+	ast_tests.cpp \
 	stack_int_tests.cpp \
 	stack_char_tests.cpp \
 	stack_charptr_tests.cpp \

--- a/tests/unit/ast_tests.cpp
+++ b/tests/unit/ast_tests.cpp
@@ -1,0 +1,29 @@
+#include "gtest/gtest.h"
+
+extern "C" {
+#include "../../src/ast.h"
+}
+
+TEST(ast_parameter, basic_operation) {
+    func_parameter_t *p = func_parameter_new();
+    ASSERT_NE(p, NULL);
+    func_parameter_free(p);
+}
+
+TEST(ast_return, basic_operation) {
+    func_return_t *r = func_return_new();
+    ASSERT_NE(r, NULL);
+    func_return_free(r);
+}
+
+TEST(ast_function, basic_operation) {
+    func_t f;
+    func_init(&f);
+
+    ASSERT_EQ(f.first_parameter, NULL);
+    ASSERT_EQ(f.first_return, NULL);
+    ASSERT_EQ(f.num_of_parameters, 0);
+    ASSERT_EQ(f.num_of_returns, 0);
+
+    func_free(&f);
+}


### PR DESCRIPTION
I came to the conclusion that I need some data structures where to store
info about entities like functions (mainly and currently solely).

I was in a rush and simply made the types in a way that they should be
allocated on the heap. Optimization should come but I doubt it will :).