### PR TITLE
Change charptr type to match the strcmp implementation

### DIFF
--- a/src/stack_charptr.h
+++ b/src/stack_charptr.h
@@ -8,8 +8,8 @@
  */
 
 // typedef to handle pointers
-typedef char* charptr;
-#define TYPEDEF typedef char* charptr
+typedef const char* charptr;
+#define TYPEDEF typedef const char* charptr
 
 #define TYPE charptr
 

--- a/tests/unit/stack_charptr_tests.cpp
+++ b/tests/unit/stack_charptr_tests.cpp
@@ -61,7 +61,7 @@ TEST_F(stack_charptr_general, test_number_of_occurences) {
 
 
 TEST_F(stack_charptr_general, peek_top) {
-    char *val = stack_charptr_peek(stack);
+    const char *val = stack_charptr_peek(stack);
     ASSERT_EQ(val, "foo");
 }
 


### PR DESCRIPTION
Switch from char* to const char* because of how the 'strcmp' function code generation team uses is implemented. There is no functional difference between char* and const char* regarding the stack implementation and its functionality, so this is safe to do. (Once the char* is pushed, it is no longer tempered with.)

I am not changing how the charptr file is generated due to saved verbosity and zero functionality change. Both `char *` and `const char *` are valid options.